### PR TITLE
Update 'Get on Google Play' image src

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,11 +46,11 @@
 				<div class="col-lg-6 center-block">
 					<img src="assets/img/antennapod-logo.png" height="150" width="150" alt="Antennapod Logo" />
 					<h1>The easy-to-use, flexible and open-source podcast manager for Android</h1>
-					<a href="https://play.google.com/store/apps/details?id=de.danoeh.antennapod">
-                        <img alt="Get it on Google Play" src="https://developer.android.com/images/brand/en_generic_rgb_wo_60.png" />
-                    </a> 
+                    <a href="https://play.google.com/store/apps/details?id=de.danoeh.antennapod">
+                         <img alt="Get it on Google Play" src="https://play.google.com/intl/en_us/badges/images/generic/en-play-badge.png" />
+                    </a>
                     <a href="https://f-droid.org/repository/browse/?fdid=de.danoeh.antennapod">
-                        <img alt="Get it on F-Droid" src="assets/img/getitonfdroid.png"  />
+                         <img alt="Get it on F-Droid" src="assets/img/getitonfdroid.png"  />
                     </a>				
 				</div><!-- /col-lg-6 -->
 				<div class="col-lg-6 center-block">


### PR DESCRIPTION
Old file location gave 404 (probably after Google's logo update), in effect removing the button from the website.