### PR TITLE
Limit Google Play button dimensions

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,7 +47,7 @@
 					<img src="assets/img/antennapod-logo.png" height="150" width="150" alt="Antennapod Logo" />
 					<h1>The easy-to-use, flexible and open-source podcast manager for Android</h1>
                     <a href="https://play.google.com/store/apps/details?id=de.danoeh.antennapod">
-                         <img alt="Get it on Google Play" src="https://play.google.com/intl/en_us/badges/images/generic/en-play-badge.png" />
+                         <img alt="Get it on Google Play" src="https://play.google.com/intl/en_us/badges/images/generic/en-play-badge.png" height="60px" />
                     </a>
                     <a href="https://f-droid.org/repository/browse/?fdid=de.danoeh.antennapod">
                          <img alt="Get it on F-Droid" src="assets/img/getitonfdroid.png"  />


### PR DESCRIPTION
Google's new icon is way larger than the original, leading to a massive icon on the website. Sorry I didn't check.