### PR TITLE
[#9] remove unnecessary menu button on small screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,11 +29,6 @@
     <div class="navbar navbar-default navbar-fixed-top">
       <div class="container">
         <div class="navbar-header">
-          <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
-            <span class="icon-bar"></span>
-            <span class="icon-bar"></span>
-            <span class="icon-bar"></span>
-          </button>
           <a class="navbar-brand" href="#"><b>ANTENNAPOD</b></a>
         </div>
       </div>


### PR DESCRIPTION
This is a fix for #9. Removes the unused menu button

![image](https://user-images.githubusercontent.com/1614/40157327-42f263a8-5953-11e8-9622-1519bbfc5361.png)
