### PR TITLE
Remove mailto: link

### DIFF
--- a/index.html
+++ b/index.html
@@ -181,7 +181,7 @@
 		<p class="centered">AntennaPod was created by Daniel Oeh and released under the MIT License.<br/>
 			            It is currently maintained by volunteers. Wanna help? Join us on <a href="https://www.github.com/antennapod/AntennaPod">GitHub</a>!</p>
                 <p class="centered">Website built using <a href="http://www.getbootstrap.com">Bootstrap, <a href="http://www.fontawesome.io/">FontAwesome</a> and the <a href="http://www.bootstrapzero.com/bootstrap-template/flatty">Flatty Template</a></p>
-		<p class="centered"><a href="https://twitter.com/antennapod"><i class="fa fa-twitter"></i></a> - <a href="mailto:antennapod@googlegroups.com"><i class="fa fa-envelope"></i></a> - <a href="https://www.github.com/antennapod/AntennaPod"><i class="fa fa-github"></i></a> - <a href="https://en.wikipedia.org/wiki/AntennaPod"><i class="fa fa-wikipedia-w"></i></a> - <a href="https://groups.google.com/forum/#!forum/antennapod"><i class="fa fa-google"></i></a> - <a href="https://www.transifex.com/antennapod/antennapod/"><i class="fa fa-language"></i></a><!-- - <a href="bitcoin:1DzvtuvdW8VhDsq9GUytMyALmsHeaHEKbg"><i class="fa fa-bitcoin"></i></a>--></p>
+		<p class="centered"><a href="https://twitter.com/antennapod"><i class="fa fa-twitter"></i></a> - <a href="https://groups.google.com/forum/#!forum/antennapod"><i class="fa fa-envelope"></i></a> - <a href="https://www.github.com/antennapod/AntennaPod"><i class="fa fa-github"></i></a> - <a href="https://en.wikipedia.org/wiki/AntennaPod"><i class="fa fa-wikipedia-w"></i></a> - <a href="https://www.transifex.com/antennapod/antennapod/"><i class="fa fa-language"></i></a><!-- - <a href="bitcoin:1DzvtuvdW8VhDsq9GUytMyALmsHeaHEKbg"><i class="fa fa-bitcoin"></i></a>--></p>
 	</div><!-- /container -->
 	
 


### PR DESCRIPTION
In the past we had an issue where users contacted the community list from the app via the email address and consequently did not get an update on any replies on their tickets. This was circumvented by providing a link to the group instead. Same issue does and solution should apply to the website.