### PR TITLE
Replace Google Group link

### DIFF
--- a/index.html
+++ b/index.html
@@ -181,7 +181,7 @@
 		<p class="centered">AntennaPod was created by Daniel Oeh and released under the MIT License.<br/>
 			            It is currently maintained by volunteers. Wanna help? Join us on <a href="https://www.github.com/antennapod/AntennaPod">GitHub</a>!</p>
                 <p class="centered">Website built using <a href="http://www.getbootstrap.com">Bootstrap, <a href="http://www.fontawesome.io/">FontAwesome</a> and the <a href="http://www.bootstrapzero.com/bootstrap-template/flatty">Flatty Template</a></p>
-		<p class="centered"><a href="https://twitter.com/antennapod"><i class="fa fa-twitter"></i></a> - <a href="https://forum.antennapod.org/"><i class="fa fa-envelope"></i></a> - <a href="https://www.github.com/antennapod/AntennaPod"><i class="fa fa-github"></i></a> - <a href="https://en.wikipedia.org/wiki/AntennaPod"><i class="fa fa-wikipedia-w"></i></a> - <a href="https://www.transifex.com/antennapod/antennapod/"><i class="fa fa-language"></i></a><!-- - <a href="bitcoin:1DzvtuvdW8VhDsq9GUytMyALmsHeaHEKbg"><i class="fa fa-bitcoin"></i></a>--></p>
+		<p class="centered"><a href="https://twitter.com/antennapod"><i class="fa fa-twitter"></i></a> - <a href="https://forum.antennapod.org/"><i class="fa fa-comments"></i></a> - <a href="https://www.github.com/antennapod/AntennaPod"><i class="fa fa-github"></i></a> - <a href="https://en.wikipedia.org/wiki/AntennaPod"><i class="fa fa-wikipedia-w"></i></a> - <a href="https://www.transifex.com/antennapod/antennapod/"><i class="fa fa-language"></i></a><!-- - <a href="bitcoin:1DzvtuvdW8VhDsq9GUytMyALmsHeaHEKbg"><i class="fa fa-bitcoin"></i></a>--></p>
 	</div><!-- /container -->
 	
 

--- a/index.html
+++ b/index.html
@@ -181,7 +181,7 @@
 		<p class="centered">AntennaPod was created by Daniel Oeh and released under the MIT License.<br/>
 			            It is currently maintained by volunteers. Wanna help? Join us on <a href="https://www.github.com/antennapod/AntennaPod">GitHub</a>!</p>
                 <p class="centered">Website built using <a href="http://www.getbootstrap.com">Bootstrap, <a href="http://www.fontawesome.io/">FontAwesome</a> and the <a href="http://www.bootstrapzero.com/bootstrap-template/flatty">Flatty Template</a></p>
-		<p class="centered"><a href="https://twitter.com/antennapod"><i class="fa fa-twitter"></i></a> - <a href="https://groups.google.com/forum/#!forum/antennapod"><i class="fa fa-envelope"></i></a> - <a href="https://www.github.com/antennapod/AntennaPod"><i class="fa fa-github"></i></a> - <a href="https://en.wikipedia.org/wiki/AntennaPod"><i class="fa fa-wikipedia-w"></i></a> - <a href="https://www.transifex.com/antennapod/antennapod/"><i class="fa fa-language"></i></a><!-- - <a href="bitcoin:1DzvtuvdW8VhDsq9GUytMyALmsHeaHEKbg"><i class="fa fa-bitcoin"></i></a>--></p>
+		<p class="centered"><a href="https://twitter.com/antennapod"><i class="fa fa-twitter"></i></a> - <a href="https://forum.antennapod.org/"><i class="fa fa-envelope"></i></a> - <a href="https://www.github.com/antennapod/AntennaPod"><i class="fa fa-github"></i></a> - <a href="https://en.wikipedia.org/wiki/AntennaPod"><i class="fa fa-wikipedia-w"></i></a> - <a href="https://www.transifex.com/antennapod/antennapod/"><i class="fa fa-language"></i></a><!-- - <a href="bitcoin:1DzvtuvdW8VhDsq9GUytMyALmsHeaHEKbg"><i class="fa fa-bitcoin"></i></a>--></p>
 	</div><!-- /container -->
 	
 


### PR DESCRIPTION
Following this forum post: https://forum.antennapod.org/t/updating-homepage-with-forum/141/5
I have replaced the google groups link with a link to the forum.

Don't know if there is another icon than the envelope for a forum.
Also not familiar enogh with html to add a forum link to the top of the site, which will be added to the redesign of the website anyway.