### PR TITLE
Fix broken "design" link

### DIFF
--- a/contribute.html
+++ b/contribute.html
@@ -13,7 +13,7 @@ permalink: /contribute/
     {% include contribute-card.html icon="fa-vial" url="/documentation/general/beta" item="test" %}
     {% include contribute-card.html icon="fa-code" url="/contribute/develop" item="develop" %}
     {% include contribute-card.html icon="fa-bullhorn" url="/contribute/promote" item="promote" %}
-    {% include contribute-card.html icon="fa-pencil-ruler" url="https://github.com/AntennaPod/AntennaPod/labels/needs%20mock-up%20or%20user%20story" item="design" %}
+    {% include contribute-card.html icon="fa-pencil-ruler" url="https://github.com/AntennaPod/AntennaPod/labels/needs:%20mock-up%20or%20user%20story" item="design" %}
   </div>
 </div>
 


### PR DESCRIPTION
This makes the link to the relevant GitHub issue type work as intended.