### PR TITLE
Improve translations>master workflow

### DIFF
--- a/.github/workflows/translation-updates-to-main-repo.yml
+++ b/.github/workflows/translation-updates-to-main-repo.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Get main repository
         uses: actions/checkout@v2
         with:
-          ref: main
+          ref: master
       - name: Get translation repository
         uses: actions/checkout@v2
         with:
@@ -131,4 +131,4 @@ jobs:
           git config user.email "<bot@antennapod.org>"
           git status
           git commit -m "Update website with new translations"
-          git push origin main
+          git push origin master

--- a/.github/workflows/translation-updates-to-main-repo.yml
+++ b/.github/workflows/translation-updates-to-main-repo.yml
@@ -128,7 +128,7 @@ jobs:
       - name: Commit changes
         run: |
           git config user.name "AntennaPod Translations Bot"
-          git config user.email "<bot@antennapod.org>"
+          git config user.email "<antennapod-bot@users.noreply.github.com>"
           git status
           git commit -m "Update website with new translations"
           git push origin master


### PR DESCRIPTION
Should probably have created an empty branch first instead of creating it with the workflow file. In any case, this PR updates the workflow file as the target branch name was wrong.

It is not very clean, but the Action to push updated translation files to main/master works on my branch. Please do give your comments on the whole workflow file, if you have any.

I used here cli git instead of the 'push subfolder' action as the folder structure is a bit complex. As far as I can see this only affects the commit author (would be Weblate when using 'push subfolder', now it is our very own 'bot').

And we should probably make translation-files a protected branch as well.