### PR TITLE
Update workflow translation-updates-to-main-repo

### DIFF
--- a/.github/workflows/translation-updates-to-main-repo.yml
+++ b/.github/workflows/translation-updates-to-main-repo.yml
@@ -43,7 +43,6 @@ jobs:
             languagelist=$(cat _config.yml | grep "languages: \[.*\]" )
             languagelist=${languagelist//[}
             languagelist=${languagelist//]}
-            echo $languagelist
             languagelist=${languagelist//'languages: '}
           fi
           languagelist=${languagelist//,}

--- a/.github/workflows/translation-updates-to-main-repo.yml
+++ b/.github/workflows/translation-updates-to-main-repo.yml
@@ -52,6 +52,22 @@ jobs:
           languagelist=${languagelist//'en'}
           # Make variable consistent between steps
           echo "languages=$languagelist" >> $GITHUB_ENV
+      - name: Make General pages
+        run: |
+          cd _i18n/en/general
+          languages=(${{ env.languages }})
+          for language in "${languages[@]}"
+          do
+            mkdir -p ../../$language/general
+          done
+          for file in *
+          do
+            for language in "${languages[@]}"
+            do
+              po2md $file --po-files ../../../translation-files/general-pages/site-general_$language.po --save ../../$language/general/$file
+              git add ../../$language/general/$file
+            done
+          done
       - name: Make Contribution pages
         run: |
           cd _i18n/en/contribute
@@ -104,23 +120,6 @@ jobs:
               done
             done
             cd ../
-          done
-      - name: Make General pages
-        run: |
-          cd _i18n/en/general
-          ls
-          languages=(${{ env.languages }})
-          for language in "${languages[@]}"
-          do
-            mkdir -p ../../$language/general
-          done
-          for file in *
-          do
-            for language in "${languages[@]}"
-            do
-              po2md $file --po-files ../../../translation-files/general-pages/site-general_$language.po --save ../../$language/general/$file
-              git add ../../$language/general/$file
-            done
           done
       - name: Stage yml files
         run: |

--- a/.github/workflows/translation-updates-to-main-repo.yml
+++ b/.github/workflows/translation-updates-to-main-repo.yml
@@ -23,20 +23,17 @@ jobs:
     name: Generate & push translated files
     runs-on: ubuntu-latest
     steps:
-        # Check out the repository and download it to the runner, allowing to run actions against the code
-      - name: Get main repository
+      - name: Install mdpo
+        run: pip install mdpo
+      - name: Get main branch
         uses: actions/checkout@v2
         with:
           ref: master
-      - name: Get translation repository
+      - name: Get translation files branch
         uses: actions/checkout@v2
         with:
           ref: translation-files
           path: translation-files
-      - run: git branch
-      - run: ls -al
-      - name: Install mdpo
-        run: pip install mdpo
       - name: Set languages
         id: lang-set
         run: |
@@ -55,28 +52,20 @@ jobs:
           languagelist=${languagelist//'en'}
           # Make variable consistent between steps
           echo "languages=$languagelist" >> $GITHUB_ENV
-      - name: Print tree
-        run: |
-          sudo apt-get install tree
-          tree -L 2
-      - name: Print languages
-        run: |
-          languages=(${{ env.languages }})
-          for language in "${languages[@]}"
-          do echo $language
-          done
       - name: Make Contribution pages
         run: |
           cd _i18n/en/contribute
           languages=(${{ env.languages }})
           for language in "${languages[@]}"
-          do mkdir -p ../../$language/contribute
+          do
+            mkdir -p ../../$language/contribute
           done
           for file in *
           do
             for language in "${languages[@]}"
-            do po2md $file --po-files ../../../translation-files/contribute-pages/site-contribute_$language.po --save ../../$language/contribute/$file
-            git add ../../$language/contribute/$file
+            do
+              po2md $file --po-files ../../../translation-files/contribute-pages/site-contribute_$language.po --save ../../$language/contribute/$file
+              git add ../../$language/contribute/$file
             done
           done
       - name: Make Documentation pages
@@ -85,13 +74,15 @@ jobs:
           cd _i18n/en/documentation
           languages=(${{ env.languages }})
           for language in "${languages[@]}"
-          do mkdir -p ../../$language/documentation
+          do
+            mkdir -p ../../$language/documentation
           done
           for file in *.md
           do
             for language in "${languages[@]}"
-            do po2md $file --po-files ../../../translation-files/documentation-pages/site-documentation_$language.po --save ../../$language/documentation/$file
-            git add ../../$language/documentation/$file
+            do
+              po2md $file --po-files ../../../translation-files/documentation-pages/site-documentation_$language.po --save ../../$language/documentation/$file
+              git add ../../$language/documentation/$file
             done
           done
           # sub-level files
@@ -101,14 +92,15 @@ jobs:
             cd $category
             languages=(${{ env.languages }})
             for language in "${languages[@]}"
-            do mkdir -p ../../../$language/documentation/$category
+            do
+              mkdir -p ../../../$language/documentation/$category
             done
             for file in *
             do
               for language in "${languages[@]}"
               do
                 po2md $file --po-files ../../../../translation-files/documentation-pages/site-documentation_$language.po --save ../../../$language/documentation/$category/$file
-              git add ../../../$language/documentation/$category/$file
+                git add ../../../$language/documentation/$category/$file
               done
             done
             cd ../
@@ -119,21 +111,24 @@ jobs:
           ls
           languages=(${{ env.languages }})
           for language in "${languages[@]}"
-          do mkdir -p ../../$language/general
+          do
+            mkdir -p ../../$language/general
           done
           for file in *
           do
             for language in "${languages[@]}"
-            do po2md $file --po-files ../../../translation-files/general-pages/site-general_$language.po --save ../../$language/general/$file
-            git add ../../$language/general/$file
+            do
+              po2md $file --po-files ../../../translation-files/general-pages/site-general_$language.po --save ../../$language/general/$file
+              git add ../../$language/general/$file
             done
           done
       - name: Stage yml files
         run: |
           languages=(${{ env.languages }})
           for language in "${languages[@]}"
-          do cp translation-files/general-strings/$language.yml _i18n/$language.yml
-          git add _i18n/$language.yml
+          do
+            cp translation-files/general-strings/$language.yml _i18n/$language.yml
+            git add _i18n/$language.yml
           done
       - name: Commit changes
         run: |


### PR DESCRIPTION
I have corrected indention and removed stuff I had included for debugging. I'm not against moving the creation of top- and second-level pages to a bash script, but I wouldn't know if all the environment variables & folder jumping would still work as expected. So I'd rather not touch it in that sense.

Once merged into the translation-files branch, it should probably also be applied to the master branch (for the manually triggered runs).