### PR TITLE
Reword sync docs to avoid confusion over servers and hosts(#183)

### DIFF
--- a/_i18n/en/documentation/general/synchronization.md
+++ b/_i18n/en/documentation/general/synchronization.md
@@ -26,24 +26,25 @@
 
 <!-- mdpo-enable -->
 
-AntennaPod currently supports two synchronization options: via [gpodder.net](https://gpodder.net/) and the [gPodder Sync app for Nextcloud](https://apps.nextcloud.com/apps/gpoddersync).
+AntennaPod supports synchronization via [gpodder.net](https://gpodder.net/) and the [gPodder Sync app for Nextcloud](https://apps.nextcloud.com/apps/gpoddersync).
 
-On gpodder.net anyone can create an account relatively easily and the service is free to use. Unfortunately the service has large numbers of users, limited funding and a lack of volunteer contributions. This means the server often is overloaded, leading to errors in AntennaPod. If possible, we therefore recommend that you use an existing account on a Nextcloud instance or start self-hosting either gpodder.net or Nextcloud.
+gpodder.net is a free podcast synchronization web service that anyone can sign up for. Unfortunately, due to the popularity of the service and limited funding, the server is often overloaded, leading to errors in AntennaPod. We recommend that more technical users start self-hosting using either Nextcloud and gPodder Sync or their own gpodder service from the [github repo](https://github.com/gpodder).
 
-## gPodder Sync app for Nextcloud
-If you have a Nextcloud account, install the gPodder Sync app or ask your server admin to do so. Once that is installed, simply go to `Settings` » `Synchronization` in AntennaPod, choose the relevant provider and enter the server address.
+After creating an account or setting up a server, the following steps will get synchronization up and running:
+1. Set-up device(s) **gPodder ONLY**
+  - Log in to your account on gpodder.net (or on your self-hosted instance)
 
-## gpodder.net & your own gpodder server
-- Create an account on gpodder.net or log in if you have one already.
+  - Create a device under `Subscriptions` » `Devices` for each client that you use:
+    <!-- mdpo-disable-next-line -->
+    <br />{{ img-devices | strip }}
 
-- After you created the account, we suggest to create a device on gpodder.net/devices/ for each client that you use:
-  <!-- mdpo-disable-next-line -->
-  <br />{{ img-devices | strip }}
+  - When you have added the devices to your account, link them using the "Configure" button. This way, gpodder.net automatically keeps the subscriptions of the chosen devices synchronized.
+    <!-- mdpo-disable-next-line -->
+    <br />{{ img-synchronize | strip }}
 
-- When you have added the devices to your account, link them using the "Configure" button. This way, gpodder.net automatically keeps the subscriptions of the activated devices synchronized.
-  <!-- mdpo-disable-next-line -->
-  <br />{{ img-synchronize | strip }}
-
-- Then go to AntennaPod's `Settings` » `Synchronization`. There you can log in to gpodder.net or even provide an alternative server if you want to host it yourself. During login, AntennaPod asks what device you are currently logged into. Select your newly created device.
-
-*Did you create a device while logging in, rather than in advance as suggested above?* Then be sure to press the `Force sync` button in AntennaPod to upload the played state of all the episodes you listened to earlier. If you don't do this, only podcasts that were added **after** linking the devices are synchronized. There is an [open issue for gpodder.net](https://github.com/gpodder/mygpo/issues/388) that requests to change the behavior.
+2. Activate AntennaPod sync.
+  - Under `Settings` » `Synchronization`, select `Choose synchronization provider`.
+  - If using Nextcloud or custom gpodder server, enter the URL (the same thing you would put in a web browser) of the service you set up, otherwise select the official server.
+  - **gPodder ONLY** Enter Username and Password.
+  - **gPodder ONLY** Select the device you created in the previous step.
+    - **NOTE:** If you didn't create a new device in the previous step and instead created one when you logged in, be sure to press the `Force sync` button upload the played state of all the episodes you listened to earlier. If you don't do this, only podcasts that were added **after** linking the devices are synchronized. There is an [open issue for gpodder.net](https://github.com/gpodder/mygpo/issues/388) that requests to change the behavior.

--- a/_i18n/en/documentation/general/synchronization.md
+++ b/_i18n/en/documentation/general/synchronization.md
@@ -28,23 +28,23 @@
 
 AntennaPod supports synchronization via [gpodder.net](https://gpodder.net/) and the [gPodder Sync app for Nextcloud](https://apps.nextcloud.com/apps/gpoddersync).
 
-gpodder.net is a free podcast synchronization web service that anyone can sign up for. Unfortunately, due to the popularity of the service and limited funding, the server is often overloaded, leading to errors in AntennaPod. We recommend that more technical users start self-hosting using either Nextcloud and gPodder Sync or their own gpodder service from the [github repo](https://github.com/gpodder).
+gpodder.net is a free podcast synchronization web service that anyone can sign up for. Unfortunately, due to the popularity of the service and limited funding, the server is often overloaded, leading to errors in AntennaPod. We strongly recommend that more technical users start self-hosting using either Nextcloud and gPodder Sync or their own gpodder service from the [github repo](https://github.com/gpodder).
 
 After creating an account or setting up a server, the following steps will get synchronization up and running:
 1. Set-up device(s) **gPodder ONLY**
-  - Log in to your account on gpodder.net (or on your self-hosted instance)
+   - Log in to your account on gpodder.net (or on your self-hosted instance)
 
-  - Create a device under `Subscriptions` » `Devices` for each client that you use:
+   - Create a device under `Subscriptions` » `Devices` for each client that you use:
     <!-- mdpo-disable-next-line -->
     <br />{{ img-devices | strip }}
 
-  - When you have added the devices to your account, link them using the "Configure" button. This way, gpodder.net automatically keeps the subscriptions of the chosen devices synchronized.
+   - When you have added the devices to your account, link them using the "Configure" button. This way, gpodder.net automatically keeps the subscriptions of the chosen devices synchronized.
     <!-- mdpo-disable-next-line -->
     <br />{{ img-synchronize | strip }}
 
-2. Activate AntennaPod sync.
-  - Under `Settings` » `Synchronization`, select `Choose synchronization provider`.
-  - If using Nextcloud or custom gpodder server, enter the URL (the same thing you would put in a web browser) of the service you set up, otherwise select the official server.
-  - **gPodder ONLY** Enter Username and Password.
-  - **gPodder ONLY** Select the device you created in the previous step.
-    - **NOTE:** If you didn't create a new device in the previous step and instead created one when you logged in, be sure to press the `Force sync` button upload the played state of all the episodes you listened to earlier. If you don't do this, only podcasts that were added **after** linking the devices are synchronized. There is an [open issue for gpodder.net](https://github.com/gpodder/mygpo/issues/388) that requests to change the behavior.
+1. Activate AntennaPod sync.
+   - Under `Settings` » `Synchronization`, select `Choose synchronization provider`.
+   - If using Nextcloud or custom gpodder server, enter the URL (the same thing you would put in a web browser) of the service you set up, otherwise select the official server.
+   - **gPodder ONLY** Enter Username and Password.
+   - **gPodder ONLY** Select the device you created in the previous step.
+      - **NOTE:** If you didn't create a new device in the previous step and instead created one when you logged in, be sure to press the `Force sync` button upload the played state of all the episodes you listened to earlier. If you don't do this, only podcasts that were added **after** linking the devices are synchronized. There is an [open issue for gpodder.net](https://github.com/gpodder/mygpo/issues/388) requesting this behavior be changed.

--- a/_i18n/en/documentation/general/synchronization.md
+++ b/_i18n/en/documentation/general/synchronization.md
@@ -26,15 +26,15 @@
 
 <!-- mdpo-enable -->
 
-## About
-AntennaPod supports synchronization via [gpodder.net](https://gpodder.net/) and the [gPodder Sync app for Nextcloud](https://apps.nextcloud.com/apps/gpoddersync).
+## Introfuction
+AntennaPod can communicate with a central point to share data about your podcasts with the other podcast apps that you use, we call this the Synchronization Server. AntennaPod can be told the location of the synchronization server via the server's hostname, which is often a URL much like you enter into your web browser, but can occasionally simply be an IP address if you set up the server yourself (or have a friend help set one up for you).
 
-gpodder.net is a free podcast synchronization web service that anyone can sign up for. Unfortunately, due to the popularity of the service and limited funding, the server is often overloaded, leading to errors in AntennaPod. We strongly recommend that more technical users start self-hosting using either [Nextcloud](https://nextcloud.com/install/#instructions-server) and [gPodder Sync](https://github.com/thrillfall/nextcloud-gpodder) or their own [gpodder service](https://gpoddernet.readthedocs.io/en/latest/dev/installation.html).
+[gpodder.net](https://gpodder.net/) provides a free podcast synchronization server that anyone can sign up for. Unfortunately, due to the popularity of the service and limited funding, this server is often overloaded, leading to errors in AntennaPod. Fortunately, for more technically inclined users, AntennaPod also supports custom gPodder instances and the [gPodder Sync app for Nextcloud](https://apps.nextcloud.com/apps/gpoddersync). In order to help reduce the load on the free server as much as possible, we strongly recommend that more technical users start self-hosting using either [Nextcloud](https://nextcloud.com/install/#instructions-server) and [gPodder Sync](https://github.com/thrillfall/nextcloud-gpodder), or their own [gpodder service](https://gpoddernet.readthedocs.io/en/latest/dev/installation.html).
 
 ## Enabling Sync
 1. Set up Nextcloud's gPodder Sync or create a gpodder.net account/server (see [extra gpodder instructions](#gpodder-specific-setup) below)
 1. In AntennaPod, nagivigate to `Settings` » `Synchronization`, and select `Choose synchronization provider`.
-1. If using Nextcloud or custom gpodder server, enter the URL of the service you set up, otherwise select the official server.
+1. If using Nextcloud or custom gpodder server, enter the hostname (URL) of the service you set up, otherwise select the official gpodder.net server.
 1. **gPodder ONLY** Enter Username and Password.
 1. **gPodder ONLY** Select the device created in the gPodder specific steps.
    - **NOTE:** If you when you logged in, instead of during the gPodder specific set-up as listed below, be sure to press the `Force sync` button upload the played state of all previously listened to episodes. If you don't do this, only podcasts that were added **after** linking the devices will be synchronized. There is an [open issue for gpodder.net](https://github.com/gpodder/mygpo/issues/388) requesting this behavior be changed.

--- a/_i18n/en/documentation/general/synchronization.md
+++ b/_i18n/en/documentation/general/synchronization.md
@@ -26,25 +26,26 @@
 
 <!-- mdpo-enable -->
 
+## About
 AntennaPod supports synchronization via [gpodder.net](https://gpodder.net/) and the [gPodder Sync app for Nextcloud](https://apps.nextcloud.com/apps/gpoddersync).
 
-gpodder.net is a free podcast synchronization web service that anyone can sign up for. Unfortunately, due to the popularity of the service and limited funding, the server is often overloaded, leading to errors in AntennaPod. We strongly recommend that more technical users start self-hosting using either Nextcloud and gPodder Sync or their own gpodder service from the [github repo](https://github.com/gpodder).
+gpodder.net is a free podcast synchronization web service that anyone can sign up for. Unfortunately, due to the popularity of the service and limited funding, the server is often overloaded, leading to errors in AntennaPod. We strongly recommend that more technical users start self-hosting using either [Nextcloud](https://nextcloud.com/install/#instructions-server) and [gPodder Sync](https://github.com/thrillfall/nextcloud-gpodder) or their own [gpodder service](https://gpoddernet.readthedocs.io/en/latest/dev/installation.html).
 
-After creating an account or setting up a server, the following steps will get synchronization up and running:
-1. Set-up device(s) **gPodder ONLY**
-   - Log in to your account on gpodder.net (or on your self-hosted instance)
+## Enabling Sync
+1. Set up Nextcloud's gPodder Sync or create a gpodder.net account/server (see [extra gpodder instructions](#gpodder-specific-setup) below)
+1. In AntennaPod, nagivigate to `Settings` » `Synchronization`, and select `Choose synchronization provider`.
+1. If using Nextcloud or custom gpodder server, enter the URL of the service you set up, otherwise select the official server.
+1. **gPodder ONLY** Enter Username and Password.
+1. **gPodder ONLY** Select the device created in the gPodder specific steps.
+   - **NOTE:** If you when you logged in, instead of during the gPodder specific set-up as listed below, be sure to press the `Force sync` button upload the played state of all previously listened to episodes. If you don't do this, only podcasts that were added **after** linking the devices will be synchronized. There is an [open issue for gpodder.net](https://github.com/gpodder/mygpo/issues/388) requesting this behavior be changed.
 
-   - Create a device under `Subscriptions` » `Devices` for each client that you use:
+### gPodder Specific Set-up
+1. Create an account and log in.
+
+1. Create a device under `Subscriptions` » `Devices` for each client that you use:
     <!-- mdpo-disable-next-line -->
     <br />{{ img-devices | strip }}
 
-   - When you have added the devices to your account, link them using the "Configure" button. This way, gpodder.net automatically keeps the subscriptions of the chosen devices synchronized.
+1. Link created devices using the "Configure" button. This way, gpodder.net automatically keeps the subscriptions of the chosen devices synchronized.
     <!-- mdpo-disable-next-line -->
     <br />{{ img-synchronize | strip }}
-
-1. Activate AntennaPod sync.
-   - Under `Settings` » `Synchronization`, select `Choose synchronization provider`.
-   - If using Nextcloud or custom gpodder server, enter the URL (the same thing you would put in a web browser) of the service you set up, otherwise select the official server.
-   - **gPodder ONLY** Enter Username and Password.
-   - **gPodder ONLY** Select the device you created in the previous step.
-      - **NOTE:** If you didn't create a new device in the previous step and instead created one when you logged in, be sure to press the `Force sync` button upload the played state of all the episodes you listened to earlier. If you don't do this, only podcasts that were added **after** linking the devices are synchronized. There is an [open issue for gpodder.net](https://github.com/gpodder/mygpo/issues/388) requesting this behavior be changed.

--- a/_i18n/en/documentation/general/synchronization.md
+++ b/_i18n/en/documentation/general/synchronization.md
@@ -26,7 +26,7 @@
 
 <!-- mdpo-enable -->
 
-## Introfuction
+## Introduction
 AntennaPod can communicate with a central point to share data about your podcasts with the other podcast apps that you use, we call this the Synchronization Server. AntennaPod can be told the location of the synchronization server via the server's hostname, which is often a URL much like you enter into your web browser, but can occasionally simply be an IP address if you set up the server yourself (or have a friend help set one up for you).
 
 [gpodder.net](https://gpodder.net/) provides a free podcast synchronization server that anyone can sign up for. Unfortunately, due to the popularity of the service and limited funding, this server is often overloaded, leading to errors in AntennaPod. Fortunately, for more technically inclined users, AntennaPod also supports custom gPodder instances and the [gPodder Sync app for Nextcloud](https://apps.nextcloud.com/apps/gpoddersync). In order to help reduce the load on the free server as much as possible, we strongly recommend that more technical users start self-hosting using either [Nextcloud](https://nextcloud.com/install/#instructions-server) and [gPodder Sync](https://github.com/thrillfall/nextcloud-gpodder), or their own [gpodder service](https://gpoddernet.readthedocs.io/en/latest/dev/installation.html).

--- a/_i18n/en/documentation/general/synchronization.md
+++ b/_i18n/en/documentation/general/synchronization.md
@@ -31,8 +31,9 @@ AntennaPod can communicate with a central point to share data about your podcast
 
 [gpodder.net](https://gpodder.net/) provides a free podcast synchronization server that anyone can sign up for. Unfortunately, due to the popularity of the service and limited funding, this server is often overloaded, leading to errors in AntennaPod. Fortunately, for more technically inclined users, AntennaPod also supports custom gPodder instances and the [gPodder Sync app for Nextcloud](https://apps.nextcloud.com/apps/gpoddersync). In order to help reduce the load on the free server as much as possible, we strongly recommend that more technical users start self-hosting using either [Nextcloud](https://nextcloud.com/install/#instructions-server) and [gPodder Sync](https://github.com/thrillfall/nextcloud-gpodder), or their own [gpodder service](https://gpoddernet.readthedocs.io/en/latest/dev/installation.html).
 
+
 ## Enabling Sync
-1. Set up Nextcloud's gPodder Sync or create a gpodder.net account/server (see [extra gpodder instructions](#gpodder-specific-setup) below)
+1. Set up Nextcloud's gPodder Sync or create a gpodder.net account/server (see [extra gpodder instructions](#gpodder-specific-set-up) below)
 1. In AntennaPod, nagivigate to `Settings` » `Synchronization`, and select `Choose synchronization provider`.
 1. If using Nextcloud or custom gpodder server, enter the hostname (URL) of the service you set up, otherwise select the official gpodder.net server.
 1. **gPodder ONLY** Enter Username and Password.

--- a/_i18n/en/documentation/general/synchronization.md
+++ b/_i18n/en/documentation/general/synchronization.md
@@ -26,27 +26,30 @@
 
 <!-- mdpo-enable -->
 
-## Introduction
-AntennaPod can communicate with a central point to share data about your podcasts with the other podcast apps that you use, we call this the Synchronization Server. AntennaPod can be told the location of the synchronization server via the server's hostname, which is often a URL much like you enter into your web browser, but can occasionally simply be an IP address if you set up the server yourself (or have a friend help set one up for you).
+AntennaPod can synchronise your subscriptions and listening progress with other AntennaPod installations as well as other (desktop) apps. To set up synchronisation, you need a server - the central point through which your data is shared with other devices. You have several options for this:
+* [gpodder.net](https://gpodder.net/) provides a free gPodder synchronization server that **anyone can sign up** for. Unfortunately, due to the popularity of the service and its limited funding, this server is often overloaded, leading to errors in AntennaPod.
+* More technically inclined users are strongly encouraged to **self-host a synchronization server**. A self-hosted server is more reliable and helps reduce the load on free, public services. There are several options: [Nextcloud](https://nextcloud.com/install/#instructions-server) with the [gPodder Sync app](https://apps.nextcloud.com/apps/gpoddersync), a full [gPodder](https://gpoddernet.readthedocs.io/en/latest/dev/installation.html) server, or the [Micro GPodder server](https://github.com/bohwaz/micro-gpodder-server).
 
-[gpodder.net](https://gpodder.net/) provides a free podcast synchronization server that anyone can sign up for. Unfortunately, due to the popularity of the service and limited funding, this server is often overloaded, leading to errors in AntennaPod. Fortunately, for more technically inclined users, AntennaPod also supports custom gPodder instances and the [gPodder Sync app for Nextcloud](https://apps.nextcloud.com/apps/gpoddersync). In order to help reduce the load on the free server as much as possible, we strongly recommend that more technical users start self-hosting using either [Nextcloud](https://nextcloud.com/install/#instructions-server) and [gPodder Sync](https://github.com/thrillfall/nextcloud-gpodder), or their own [gpodder service](https://gpoddernet.readthedocs.io/en/latest/dev/installation.html).
 
+## Enable synchronization via Nextcloud
+1. If you have a Nextcloud account, install the gPodder Sync app or ask your server admin to do so
+2. Go to `Settings` » `Synchronization` in AntennaPod and tap `Choose synchronization provider`
+3. Select 'Nextcloud'
+4. Enter the 'Server address' (the URL or IP address of the server) and tap `Proceed`
+5. Log in on the browser window that opens and authorize AntennaPod
 
-## Enabling Sync
-1. Set up Nextcloud's gPodder Sync or create a gpodder.net account/server (see [extra gpodder instructions](#gpodder-specific-set-up) below)
-1. In AntennaPod, nagivigate to `Settings` » `Synchronization`, and select `Choose synchronization provider`.
-1. If using Nextcloud or custom gpodder server, enter the hostname (URL) of the service you set up, otherwise select the official gpodder.net server.
-1. **gPodder ONLY** Enter Username and Password.
-1. **gPodder ONLY** Select the device created in the gPodder specific steps.
-   - **NOTE:** If you when you logged in, instead of during the gPodder specific set-up as listed below, be sure to press the `Force sync` button upload the played state of all previously listened to episodes. If you don't do this, only podcasts that were added **after** linking the devices will be synchronized. There is an [open issue for gpodder.net](https://github.com/gpodder/mygpo/issues/388) requesting this behavior be changed.
-
-### gPodder Specific Set-up
-1. Create an account and log in.
-
-1. Create a device under `Subscriptions` » `Devices` for each client that you use:
+## Enable synchronization via gPodder
+1. Create an account on the server www.gpodder.net or on your own server
+2. When you have an account, log in on the webserver and create a device under `Subscriptions` » `Devices` for each client that you use:
     <!-- mdpo-disable-next-line -->
     <br />{{ img-devices | strip }}
+3. When you have added the devices to your account, link them using the "Configure" button. This way, gpodder.net automatically keeps the activated devices synchronized.
+  <!-- mdpo-disable-next-line -->
+  <br />{{ img-synchronize | strip }}
+4. Go to `Settings` » `Synchronization` in AntennaPod and tap `Choose synchronization provider`
+5. Select 'gPodder'
+6. Enter the 'Server address' (e.g. www.gpodder.net) and tap `Proceed to login`
+7. Enter the 'Username' and 'Password' and tap `Log in`
+8. Select the device that you created on the server
 
-1. Link created devices using the "Configure" button. This way, gpodder.net automatically keeps the subscriptions of the chosen devices synchronized.
-    <!-- mdpo-disable-next-line -->
-    <br />{{ img-synchronize | strip }}
+**NOTE:** Did you create a device while setting up synchronisation in AntennaPod, rather creating a device in advance on the website? Then be sure to press the `Force sync` button upload the played state of all previously listened to episodes. If you don't do this, only podcasts that were added **after** linking the devices will be synchronized. There is an [open issue for gpodder.net](https://github.com/gpodder/mygpo/issues/388) that requests to change the behavior.


### PR DESCRIPTION
I reworded and re-ordered things to hopefully clear up some of the confusion as seen in #183. I also took a few in-app screenshots that I thought might help, but then decided that they would probably just end up bloating the page without actually adding much.  Happy to add them in if they are desirable.