### PR TITLE
Explain playback on Android Auto

### DIFF
--- a/_documentation/playback/android-auto.md
+++ b/_documentation/playback/android-auto.md
@@ -1,0 +1,11 @@
+---
+title: documentation.categories.playback.android-auto
+layout: doc
+level: "2"
+group: "playback"
+icon: "fas fa-car"
+---
+
+# {% t {{ page.title }} %}
+
+{% tf documentation/{{ page.group }}/{{ page.slug }}.md %}

--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -145,6 +145,7 @@ documentation:
       intro: "Below, you can find topics related to playback."
       auto-rewind: "Automatic rewind"
       shortcuts: "Hardware keyboard shortcuts"
+      android-auto: "Playback in cars (Andoid Auto)"
     queue:
       title: "Queue"
       intro: "Below, you can find frequently asked questions about the queue."

--- a/_i18n/en/documentation/playback/android-auto.md
+++ b/_i18n/en/documentation/playback/android-auto.md
@@ -1,0 +1,14 @@
+You can use AntennaPod to listen to podcasts in your [Android Auto](https://www.android.com/auto/) enabled car.
+
+### Did you download AntennaPod from **Google Play**?
+
+No further steps are required to use AntennaPod in your car. Just connect your phone and start listening.
+
+### Did you download AntennaPod from **F-Droid**?
+
+If you downloaded AntennaPod from F-Droid, further steps are required.
+
+  - Open the Android Auto settings.
+  - Enable `Developer settings` by pressing the version number 10 times.
+  - Open the 3-dot menu and launch the developer settings.
+  - Enable `Unknown sources`.


### PR DESCRIPTION
I see quite a few users who don't realize they can use AntennaPod on Android Auto. Maybe the reason is that they use F-Droid. This PR adds a documentation page to explain what one needs to to in order to use the F-Droid version with Android Auto.