### PR TITLE
Change iTunes to Apple Podcasts in documentation

### DIFF
--- a/_i18n/en/documentation/getting-started/subscribe.md
+++ b/_i18n/en/documentation/getting-started/subscribe.md
@@ -3,7 +3,7 @@ The first thing you want to do after downloading a podcast app is to subscribe t
 ## Subscribing
 Open the drawer by swiping from the left or tapping the `☰` burger icon on the top left corner. Go to `+ Add Podcast`. Now, you can search, browse suggestions or add a podcast with its RSS address.
 
-Alternatively, you can import an OPML file or only check the iTunes, gpodder.net, fyyd or Podcast Index database respectively. Importing RSS or Atom feeds, or URL schemes like `pcast://` and `itpc://`, will also work.
+Alternatively, you can import an OPML file or only check the Apple Podcasts, gpodder.net, fyyd or Podcast Index database respectively. Importing RSS or Atom feeds, or URL schemes like `pcast://` and `itpc://`, will also work.
 
 ## Subscribing to third-party services
 We got some questions about support for platforms like SoundCloud, Mixcloud and alike. While it may be cool to have a feature to simply paste/open channel URLs in AntennaPod, [it's been decided](https://github.com/AntennaPod/AntennaPod/issues/1297) to not implement it. Such platforms may come and disappear, while it's quite some work for our volunteers to implement this feature. If you're a developer, you're of course welcome to discuss a proposal that you'd be happy to implement.

--- a/_i18n/en/documentation/podcasters-hosters/list-podcast.md
+++ b/_i18n/en/documentation/podcasters-hosters/list-podcast.md
@@ -2,7 +2,7 @@ If you are a podcast producer and want to make your podcast visible in AntennaPo
 
 AntennaPod mainly uses three directories for its search feature:
 * [Podcast Index](https://podcastindex.org/) (ask your hoster how to add your podcast, or add your own podcast via the [API](https://podcastindex-org.github.io/docs-api/#get-/add/byfeedurl))
-* [iTunes](https://podcasts.apple.com) (add via [Podcast Connect](https://podcastsconnect.apple.com/))
+* [Apple Podcasts](https://podcasts.apple.com) (add via [Podcast Connect](https://podcastsconnect.apple.com/))
 * [Fyyd](https://fyyd.de/) (add via their [website](https://fyyd.de/add-feed))
 
 If your podcast is available in either of them, it can be found in AntennaPod.


### PR DESCRIPTION
Applies to page: Documentation / Podcasters hosters / Getting your podcast listed 
Based on the suggestion in the forum here: https://forum.antennapod.org/t/itunes-referred-to-throughout-the-app-doesnt-exist/2725