### PR TITLE
Add dependabot & update GH Actions dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 2
+    assignees:
+      - "keunes"

--- a/.github/workflows/autoreview.yml
+++ b/.github/workflows/autoreview.yml
@@ -3,22 +3,22 @@ on: [pull_request]
 
 jobs:
   misspellcheck:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Run misspell with reviewdog
       uses: reviewdog/action-misspell@v1
       with:
         pattern: "*.md"
   guids:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - run: .github/workflows/guids.sh
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: sudo apt-get install ruby-full build-essential zlib1g-dev git
       - uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/en-updates-to-translation-repo.yml
+++ b/.github/workflows/en-updates-to-translation-repo.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install mdpo
         run: pip install mdpo
       - name: Create folder for files to be copied

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,9 +9,9 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: sudo apt-get install ruby-full build-essential zlib1g-dev git
       - uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/translation-updates-to-main-repo.yml
+++ b/.github/workflows/translation-updates-to-main-repo.yml
@@ -25,11 +25,11 @@ jobs:
     steps:
         # Check out the repository and download it to the runner, allowing to run actions against the code
       - name: Get main repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: master
       - name: Get translation repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: translation-files
           path: translation-files


### PR DESCRIPTION
Currently there is no package manager or similar for GH Actions to manage the dependencies.
Dependabot offers to monitor the workflow scripts and propose new versions as PR.
Since GH Actions rarely change and no resources should be wasted, a repetition of one month is sufficient.

I would recommend to add the dependabot.yml to every repository with GH action script.

## Reference

fixes #199