### PR TITLE
Fix validator.w3.org warnings and erros

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -10,8 +10,11 @@
         <div class="container">
             <div class="row pt-2 mb-4 mb-lg-3 justify-content-between">
                 <div class="col-12 col-lg-4 col-md-12 mb-3">
-                    <div class="small mb-4 mb-lg-3"><a href="/{% if site.lang != 'en' %}{{ site.lang }}{% endif %}"><img
-                                src="{{ site.baseurl_root }}/assets/logos/logo.png" width="260px" /></a></div>
+                    <div class="small mb-4 mb-lg-3">
+                        <a href="/{% if site.lang != 'en' %}{{ site.lang }}{% endif %}">
+                            <img src="{{ site.baseurl_root }}/assets/logos/logo.png" width="260" alt="{% t generic.accessibility.logo %}"/>
+                        </a>
+                    </div>
                     <p class="size-14 color-gray-900 mb-3">{% t footer.description %}</p>
                 </div>
                 <div class="col-0 col-lg-2"></div>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -54,7 +54,7 @@
   <link rel="mask-icon" href="/assets/images/favicons/safari-pinned-tab.svg" color="#2a854e">
   <meta name="msapplication-TileColor" content="#2a854e">
   <meta name="theme-color" content="#2a854e">
-  <link rel="shortcut icon" href="/assets/images/favicons/favicon.ico" type="image/x-icon" />
+  <link rel="shortcut icon" href="/assets/images/favicons/favicon.ico" type="image/x-icon">
 
   <!-- Resources -->
   <link rel="stylesheet" href="/assets/css/main.css">
@@ -62,4 +62,4 @@
   <script src="/assets/js/jquery.min.js"></script>
   <script src="/assets/js/bootstrap.bundle.min.js"></script>
   <script defer src="/assets/js/search.min.js"></script>
-  <script defer type="text/javascript" src="/assets/js/copy-url.js"></script>
+  <script defer src="/assets/js/copy-url.js"></script>

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -3,7 +3,7 @@
         <div class="navbar navbar-expand-xl justify-content-between">
             <div>
                 <a href="/{% if site.lang != 'en' %}{{ site.lang }}{% endif %}">
-                    <img class="smallermobile" src="/assets/logos/logo.png" id="mainlogo" />
+                    <img class="smallermobile" src="/assets/logos/logo.png" id="mainlogo" alt="{% t generic.accessibility.logo %}"/>
                 </a>
             </div>
             <div class="collapse navbar-collapse flex-grow-0 weight-500">
@@ -16,7 +16,7 @@
                     <div class="nav-item ml-0 ml-sm-1 text-center">
                         <li class="nav-item dropdown mb-0">
                             <button class="nav-link dropdown-toggle" id="navbarDropdown" aria-label="{% t generic.accessibility.lang-menu %}"
-                                role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                                data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                                 <i class="fa fa-globe size-16 color-gray-900"></i><span
                                     class="ml-1 size-16 color-gray-900 weight-600">{{ site.lang | upcase }}</span>
                             </button>
@@ -31,7 +31,7 @@
                 <div class="nav-item text-center d-inline-block">
                     <div class="nav-item dropdown">
                         <button class="nav-link dropdown-toggle" id="navbarDropdown" aria-label="{% t generic.accessibility.lang-menu %}"
-                            role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                            data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                             <i class="fa fa-globe size-16 color-gray-900"></i><span
                                 class="ml-1 size-16 color-gray-900 weight-600">{{ site.lang | upcase }}</span>
                         </button>
@@ -40,16 +40,16 @@
                         </div>
                     </div>
                 </div>
-                <button class="navbar-toggler" onclick="openNav()"><img
-                        src="{{ site.baseurl_root }}/assets/images/icons/burger.svg" /></button>
+                <button class="navbar-toggler" onclick="openNav()">
+                    <img src="{{ site.baseurl_root }}/assets/images/icons/burger.svg" alt="{% t generic.accessibility.lang-menu %}"/>
+                </button>
             </div>
         </div>
 
         <div id="navbar-mobile" class="overlay">
             <button class="closebtn" onclick="closeNav()">&times;</button>
             <div class="overlay-header">
-                <img src="{{ site.baseurl_root }}/assets/logos/icon.png" width="80px" height="auto"
-                    alt="{% t generic.accessibility.logo %}" />
+                <img src="{{ site.baseurl_root }}/assets/logos/icon.png" width="80" alt="{% t generic.accessibility.logo %}"/>
             </div>
             <div class="overlay-content">
                 {% for link in site.data.navbar %}


### PR DESCRIPTION
* Info: Trailing slash on void elements has no effect and interacts badly with unquoted attribute values.
* Warning: The type attribute is unnecessary for JavaScript resources.
* Error: An img element must have an alt attribute, except under certain conditions. For details, consult guidance on providing text alternatives for images.
* Error: Bad value for attribute width on element img: The empty string is not a valid non-negative integer.
* Error: Bad value 260px for attribute width on element img: Expected a digit but saw p instead.
* Warning: The button role is unnecessary for element button.