### PR TITLE
Fix validator.w3.org warnings

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -54,7 +54,7 @@
   <link rel="mask-icon" href="/assets/images/favicons/safari-pinned-tab.svg" color="#2a854e">
   <meta name="msapplication-TileColor" content="#2a854e">
   <meta name="theme-color" content="#2a854e">
-  <link rel="shortcut icon" href="/assets/images/favicons/favicon.ico" type="image/x-icon" />
+  <link rel="shortcut icon" href="/assets/images/favicons/favicon.ico" type="image/x-icon">
 
   <!-- Resources -->
   <link rel="stylesheet" href="/assets/css/main.css">
@@ -62,4 +62,4 @@
   <script src="/assets/js/jquery.min.js"></script>
   <script src="/assets/js/bootstrap.bundle.min.js"></script>
   <script defer src="/assets/js/search.min.js"></script>
-  <script defer type="text/javascript" src="/assets/js/copy-url.js"></script>
+  <script defer src="/assets/js/copy-url.js"></script>


### PR DESCRIPTION
* Info: Trailing slash on void elements has no effect and interacts badly with unquoted attribute values.
* Warning: The type attribute is unnecessary for JavaScript resources.

## Reference

Part from original pr #223