### PR TITLE
Fix validator.w3.org erros

### DIFF
--- a/_layouts/blog.html
+++ b/_layouts/blog.html
@@ -25,7 +25,7 @@
               <div class="row no-gutters align-items-center justify-content-between my-3">
                 <p class="size-14 weight-700 color-gray-900 mb-0">
                   {% if author %}
-                  <img class="round-img" src="{{ site.baseurl_root }}/assets/images/authors/{{ author.image }}" width="40px" height="auto" />
+                  <img class="round-img" src="{{ site.baseurl_root }}/assets/images/authors/{{ author.image }}" width="40" />
                   <a class="underline" href="{{ author.web }}" target="_blank" rel="noopener">{{ author.name }}</a>
                   {% endif %}
                   • 


### PR DESCRIPTION
* Error: Bad value 40px for attribute width on element img: Expected a digit but saw p instead.