### PR TITLE
Fix Download page image formatting to actually link to F-Droid and Google Play

### DIFF
--- a/_i18n/da/general/download.md
+++ b/_i18n/da/general/download.md
@@ -1,26 +1,37 @@
-{% capture img-GP %} {% include image.html alt="
+<!-- mdpo-disable -->
 
+{% capture img-GP %}
+{% include image.html
+   alt="
+       <!-- mdpo-enable-next-line -->
        Få den på Google Play
 
        "
+   url="https://play.google.com/store/apps/details?id=de.danoeh.antennapod"
+   loc="/assets/images/badges"
+   file="get-it-on-google-play.png"
+   width="170"
+%}
+{% endcapture %}
 
-loc="/assets/images/badges" file="get-it-on-google-play.png" width="170" %} {%
-endcapture %}
-
-{% capture img-FD %} {% include image.html alt="
-
+{% capture img-FD %}
+{% include image.html
+   alt="
+       <!-- mdpo-enable-next-line -->
        Få den på F-Droid
 
        "
-
-loc="/assets/images/badges" file="get-it-on-fdroid.png" width="170" %} {%
-endcapture %}
+   url="https://f-droid.org/packages/de.danoeh.antennapod/"
+   loc="/assets/images/badges"
+   file="get-it-on-fdroid.png"
+   width="170"
+%}
+{% endcapture %}
 
 Officielle versioner af AntennaPod er tilgængelige på Google Play og F-Droid:
 
-[{{ img-GP | strip }}](https://play.google.com/store/apps/details?
-id=de.danoeh.antennapod) [{{ img-FD |
-strip }}](https://f-droid.org/packages/de.danoeh.antennapod/)
+<!-- mdpo-disable-next-line -->
+{{ img-GP | strip }} {{ img-FD | strip }}
 
 AntennaPod udgives kun officielt i de to ovennævnte butikker, da vi ikke har tid
 til at understøtte flere. Alle andre butikker, der tilbyder AntennaPod, har

--- a/_i18n/de/general/download.md
+++ b/_i18n/de/general/download.md
@@ -1,26 +1,39 @@
-{% capture img-GP %} {% include image.html alt="
+<!-- mdpo-disable -->
 
+{% capture img-GP %}
+{% include image.html
+   alt="
+       <!-- mdpo-enable-next-line -->
        Hole es dir auf Google Play
 
        "
+   url="https://play.google.com/store/apps/details?id=de.danoeh.antennapod"
+   loc="/assets/images/badges"
+   file="get-it-on-google-play.png"
+   width="170"
+%}
+{% endcapture %}
 
-loc="/assets/images/badges" file="get-it-on-google-play.png" width="170" %} {%
-endcapture %}
-
-{% capture img-FD %} {% include image.html alt="
-
+{% capture img-FD %}
+{% include image.html
+   alt="
+       <!-- mdpo-enable-next-line -->
        Hole es dir auf F-Droid
 
        "
+   url="https://f-droid.org/packages/de.danoeh.antennapod/"
+   loc="/assets/images/badges"
+   file="get-it-on-fdroid.png"
+   width="170"
+%}
+{% endcapture %}
 
-loc="/assets/images/badges" file="get-it-on-fdroid.png" width="170" %} {%
-endcapture %}
+<!-- mdpo-enable -->
 
 Offizielle Versionen von AntennaPod sind auf Google Play und F-Droid verfügbar:
 
-[{{ img-GP | strip }}](https://play.google.com/store/apps/details?
-id=de.danoeh.antennapod) [{{ img-FD |
-strip }}](https://f-droid.org/packages/de.danoeh.antennapod/)
+<!-- mdpo-disable-next-line -->
+{{ img-GP | strip }} {{ img-FD | strip }}
 
 AntennaPod wird offiziell nur in den beiden oben genannten App Stores
 veröffentlicht, da wir nicht die Zeit haben, mehr zu unterstützen. Alle anderen,

--- a/_i18n/en/general/download.md
+++ b/_i18n/en/general/download.md
@@ -7,6 +7,7 @@
        Get it on Google Play
 
        "
+   url="https://play.google.com/store/apps/details?id=de.danoeh.antennapod"
    loc="/assets/images/badges"
    file="get-it-on-google-play.png"
    width="170"
@@ -20,6 +21,7 @@
        Get it on F-Droid
 
        "
+   url="https://f-droid.org/packages/de.danoeh.antennapod/"
    loc="/assets/images/badges"
    file="get-it-on-fdroid.png"
    width="170"
@@ -31,7 +33,7 @@
 Official versions of AntennaPod are available on Google Play and F-Droid:
 
 <!-- mdpo-disable-next-line -->
-[{{ img-GP | strip }}](https://play.google.com/store/apps/details?id=de.danoeh.antennapod) [{{ img-FD | strip }}](https://f-droid.org/packages/de.danoeh.antennapod/)
+{{ img-GP | strip }} {{ img-FD | strip }}
 
 AntennaPod is only officially published in above two app stores because we don't have the time to support more. All other stores listing AntennaPod copied the app without our explicit permission. We are not responsible for updating those or making sure they work correctly. The F-Droid repository is not maintained by us, but by the people behind F-Droid. F-Droid usually takes a few days until updates get available ([read more](/documentation/general/f-droid)). If an update is still not available more than a week after its release, feel free to let us know by creating a post on our [forum](https://forum.antennapod.org/)), and we'll investigate it.
 

--- a/_i18n/es/general/download.md
+++ b/_i18n/es/general/download.md
@@ -1,26 +1,39 @@
-{% capture img-GP %} {% include image.html alt="
+<!-- mdpo-disable -->
 
+{% capture img-GP %}
+{% include image.html
+   alt="
+       <!-- mdpo-enable-next-line -->
        Disponible en Google Play
 
        "
+   url="https://play.google.com/store/apps/details?id=de.danoeh.antennapod"
+   loc="/assets/images/badges"
+   file="get-it-on-google-play.png"
+   width="170"
+%}
+{% endcapture %}
 
-loc="/assets/images/badges" file="get-it-on-google-play.png" width="170" %} {%
-endcapture %}
-
-{% capture img-FD %} {% include image.html alt="
-
+{% capture img-FD %}
+{% include image.html
+   alt="
+       <!-- mdpo-enable-next-line -->
        Disponible en F-Droid
 
        "
+   url="https://f-droid.org/packages/de.danoeh.antennapod/"
+   loc="/assets/images/badges"
+   file="get-it-on-fdroid.png"
+   width="170"
+%}
+{% endcapture %}
 
-loc="/assets/images/badges" file="get-it-on-fdroid.png" width="170" %} {%
-endcapture %}
+<!-- mdpo-enable -->
 
 Puedes descargar versiones oficiales de AntennaPod en Google Play y en F-Droid:
 
-[{{ img-GP | strip }}](https://play.google.com/store/apps/details?
-id=de.danoeh.antennapod) [{{ img-FD |
-strip }}](https://f-droid.org/packages/de.danoeh.antennapod/)
+<!-- mdpo-disable-next-line -->
+{{ img-GP | strip }} {{ img-FD | strip }}
 
 AntennaPod solo está publicado de manera oficial en las dos tiendas de arriba
 porque no tenemos tiempo para estar en más. Todas las otras tiendas que listen

--- a/_i18n/fr/general/download.md
+++ b/_i18n/fr/general/download.md
@@ -1,27 +1,40 @@
-{% capture img-GP %} {% include image.html alt="
+<!-- mdpo-disable -->
 
+{% capture img-GP %}
+{% include image.html
+   alt="
+       <!-- mdpo-enable-next-line -->
        Téléchargez-le sur Google Play
 
        "
+   url="https://play.google.com/store/apps/details?id=de.danoeh.antennapod"
+   loc="/assets/images/badges"
+   file="get-it-on-google-play.png"
+   width="170"
+%}
+{% endcapture %}
 
-loc="/assets/images/badges" file="get-it-on-google-play.png" width="170" %} {%
-endcapture %}
-
-{% capture img-FD %} {% include image.html alt="
-
+{% capture img-FD %}
+{% include image.html
+   alt="
+       <!-- mdpo-enable-next-line -->
        Téléchargez-le sur F-Droid
 
        "
+   url="https://f-droid.org/packages/de.danoeh.antennapod/"
+   loc="/assets/images/badges"
+   file="get-it-on-fdroid.png"
+   width="170"
+%}
+{% endcapture %}
 
-loc="/assets/images/badges" file="get-it-on-fdroid.png" width="170" %} {%
-endcapture %}
+<!-- mdpo-enable -->
 
 Vous pouvez télécharger les versions officielles d'AntennaPod sur Google Play et
-sur F-Droid :
+sur F-Droid:
 
-[{{ img-GP | strip }}](https://play.google.com/store/apps/details?
-id=de.danoeh.antennapod) [{{ img-FD |
-strip }}](https://f-droid.org/packages/de.danoeh.antennapod/)
+<!-- mdpo-disable-next-line -->
+{{ img-GP | strip }} {{ img-FD | strip }}
 
 AntennaPod n'est officiellement publié que dans les deux AppStores pré-cités, car
 nous n'avons pas le temps d'en gérer davantage. Tous les autres AppStores

--- a/_i18n/it/general/download.md
+++ b/_i18n/it/general/download.md
@@ -1,26 +1,39 @@
-{% capture img-GP %} {% include image.html alt="
+<!-- mdpo-disable -->
 
+{% capture img-GP %}
+{% include image.html
+   alt="
+       <!-- mdpo-enable-next-line -->
        Scaricala da Google Play
 
        "
+   url="https://play.google.com/store/apps/details?id=de.danoeh.antennapod"
+   loc="/assets/images/badges"
+   file="get-it-on-google-play.png"
+   width="170"
+%}
+{% endcapture %}
 
-loc="/assets/images/badges" file="get-it-on-google-play.png" width="170" %} {%
-endcapture %}
-
-{% capture img-FD %} {% include image.html alt="
-
+{% capture img-FD %}
+{% include image.html
+   alt="
+       <!-- mdpo-enable-next-line -->
        Scaricala da F-Droid
 
        "
+   url="https://f-droid.org/packages/de.danoeh.antennapod/"
+   loc="/assets/images/badges"
+   file="get-it-on-fdroid.png"
+   width="170"
+%}
+{% endcapture %}
 
-loc="/assets/images/badges" file="get-it-on-fdroid.png" width="170" %} {%
-endcapture %}
+<!-- mdpo-enable -->
 
 Le versioni ufficiali di AntennaPod sono disponibili su Google Play e F-Droid:
 
-[{{ img-GP | strip }}](https://play.google.com/store/apps/details?
-id=de.danoeh.antennapod) [{{ img-FD |
-strip }}](https://f-droid.org/packages/de.danoeh.antennapod/)
+<!-- mdpo-disable-next-line -->
+{{ img-GP | strip }} {{ img-FD | strip }}
 
 AntennaPod è pubblicato ufficialmente solo su questi due app store perché non
 abbiamo il tempo di supportarne altri. Tutti gli altri store che hanno in

--- a/_i18n/nl/general/download.md
+++ b/_i18n/nl/general/download.md
@@ -1,26 +1,39 @@
-{% capture img-GP %} {% include image.html alt="
+<!-- mdpo-disable -->
 
+{% capture img-GP %}
+{% include image.html
+   alt="
+       <!-- mdpo-enable-next-line -->
        Download het op Google Play
 
        "
+   url="https://play.google.com/store/apps/details?id=de.danoeh.antennapod"
+   loc="/assets/images/badges"
+   file="get-it-on-google-play.png"
+   width="170"
+%}
+{% endcapture %}
 
-loc="/assets/images/badges" file="get-it-on-google-play.png" width="170" %} {%
-endcapture %}
-
-{% capture img-FD %} {% include image.html alt="
-
+{% capture img-FD %}
+{% include image.html
+   alt="
+       <!-- mdpo-enable-next-line -->
        Download het op F-Droid
 
        "
+   url="https://f-droid.org/packages/de.danoeh.antennapod/"
+   loc="/assets/images/badges"
+   file="get-it-on-fdroid.png"
+   width="170"
+%}
+{% endcapture %}
 
-loc="/assets/images/badges" file="get-it-on-fdroid.png" width="170" %} {%
-endcapture %}
+<!-- mdpo-enable -->
 
 Officiële versies van AntennaPod zijn beschikbaar via Google Play en F-Droid:
 
-[{{ img-GP | strip }}](https://play.google.com/store/apps/details?
-id=de.danoeh.antennapod) [{{ img-FD |
-strip }}](https://f-droid.org/packages/de.danoeh.antennapod/)
+<!-- mdpo-disable-next-line -->
+{{ img-GP | strip }} {{ img-FD | strip }}
 
 AntennaPod is alleen officieel gepubliceerd in de twee bovengenoemde winkels
 omdat we geen tijd hebben om de app op meer plekken publiceren. Alle andere

--- a/_includes/image.html
+++ b/_includes/image.html
@@ -2,6 +2,7 @@
 {%- capture english-url %}{{ include.loc }}/en/{{ include.file }}{% endcapture %}
 {%- capture single-url %}{{ include.loc }}/{{ include.file }}{% endcapture %}
 {%- assign img-alt = include.alt | remove:'<!-- mdpo-enable-next-line -->' | strip %}
+{%- assign img-url = include.url %}
 
 {%- for file in site.static_files %}
    {%- if file.path == native-url %}
@@ -21,7 +22,7 @@
    {%- endif %}
 {%- endcapture -%}
 
-<a href="" data-toggle="modal" data-target="#imgModal{{ include.file | remove:'.' }}">
+<a href="{{ include.url }}" data-toggle="modal" data-target="#imgModal{{ include.file | remove:'.' }}">
   <img src="{{ url }}" alt="{{ img-alt }}"
     {%- if include.width %} width="{{ include.width }}"{% endif %}
     {%- if include.max-width %} style="max-width:{{ include.max-width }};"{% endif %}

--- a/_includes/image.html
+++ b/_includes/image.html
@@ -22,11 +22,22 @@
    {%- endif %}
 {%- endcapture -%}
 
-<a href="{{ include.url }}" data-toggle="modal" data-target="#imgModal{{ include.file | remove:'.' }}">
+{%- if include.url %}
+<a href="{{ include.url }}">
   <img src="{{ url }}" alt="{{ img-alt }}"
     {%- if include.width %} width="{{ include.width }}"{% endif %}
     {%- if include.max-width %} style="max-width:{{ include.max-width }};"{% endif %}
-    class="rounded {{ include.class }}"></a>
+    class="rounded {{ include.class }}">
+ </a>
+{% else %}
+<a href="" 
+    data-toggle="modal" data-target="#imgModal{{ include.file | remove:'.' }}">
+  <img src="{{ url }}" alt="{{ img-alt }}"
+    {%- if include.width %} width="{{ include.width }}"{% endif %}
+    {%- if include.max-width %} style="max-width:{{ include.max-width }};"{% endif %}
+    class="rounded {{ include.class }}">
+ </a>
+{% endif %}
 
 <div class="modal fade" id="imgModal{{ include.file | remove:'.' }}" tabindex="-1" role="dialog" aria-labelledby="imgModalLabel" aria-hidden="true">
   <div class="modal-dialog modal-dialog-centered modal-lg" role="document">


### PR DESCRIPTION
Hi!

I noticed that your download page is currently kinda broken. The URLs exist, but there's some broken markdown showing on the page itself. But you don't have to take my word for it: https://antennapod.org/download/

I took the liberty of fixing the issue (on all languages) by passing a URL argument to the image display code. Existing images that don't pass a URL will still display a modal exactly as before. But images that *do* pass a URL will now load that URL on click (instead of the modal).

I'm not sure if there's any hoops I have to jump through to get this contribution accepted, but let me know if I need to sign any agreements or adjust my commits to get this change in. Thanks!