### PR TITLE
Update GH Actions dependencies

### DIFF
--- a/.github/workflows/en-updates-to-translation-repo.yml
+++ b/.github/workflows/en-updates-to-translation-repo.yml
@@ -34,7 +34,7 @@ jobs:
         run: md2po _i18n/en/general/*.md --po-filepath _i18n/translation-files/site-general.pot --save --quiet
       - name: Push to translation-files branch
         # see https://github.com/s0/git-publish-subdir-action
-        uses: s0/git-publish-subdir-action@v2.5.0
+        uses: s0/git-publish-subdir-action@v2
         env:
           REPO: self
           BRANCH: translation-files

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,9 +19,9 @@ jobs:
       - run: gem install bundler jekyll --no-document
       - run: bundle install
       - run: bundle exec jekyll build
-      - uses: JamesIves/github-pages-deploy-action@3.7.1
+      - uses: JamesIves/github-pages-deploy-action@4
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BRANCH: gh-pages
-          FOLDER: _site
-          CLEAN: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: gh-pages
+          folder: _site
+          clean: true


### PR DESCRIPTION
## Change

Just use mayor version to avoid chore of updating dependencies. Actions barely have breaking changes within a major release.

## Reference

`github-pages-deploy-action` v3 to v4 migration guide: https://github.com/JamesIves/github-pages-deploy-action/discussions/592

Obsoletes #252
Obsoletes #253