### PR TITLE
Update GH Actions

### DIFF
--- a/.github/workflows/autoreview.yml
+++ b/.github/workflows/autoreview.yml
@@ -19,10 +19,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
-      - run: sudo apt-get install ruby-full build-essential zlib1g-dev git
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.2.0'
-      - run: gem install bundler jekyll --no-document
-      - run: bundle install
+          ruby-version: '3.2'
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
       - run: bundle exec jekyll build


### PR DESCRIPTION
## Changes

* Add GH Actions caching
* Use ruby minor dependency to use automatically latest patch version
* Remove outdated `apt install`

## Advantage

Build time if cached dependencies available 2 minutes => 20 seconds.