### PR TITLE
feat(dependabot): group dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,7 @@ updates:
     open-pull-requests-limit: 2
     assignees:
       - "keunes"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Change

If there are multiple updates, dependabot will only open one PR with all the updates.

Currently the dependabot would open separate PRs for every updated dependency.

## Reference

New feature: https://github.blog/2023-08-24-a-faster-way-to-manage-version-updates-with-dependabot/