### PR TITLE
Refactor GH Actions build and deploy

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,15 +12,15 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-      - run: sudo apt-get install ruby-full build-essential zlib1g-dev git
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.2.0'
-      - run: gem install bundler jekyll --no-document
-      - run: bundle install
+          ruby-version: '3.2'
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
       - run: bundle exec jekyll build
       - run: touch _site/.nojekyll
-      - uses: JamesIves/github-pages-deploy-action@v4
+      - name: Deploy to gh-pages branch
+        uses: JamesIves/github-pages-deploy-action@v4
+        if: github.repository_owner == 'antennapod' # do not run on forks
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: gh-pages


### PR DESCRIPTION
## Change

* Use ruby minor dependency to use automatically latest patch version
* Add GH Actions caching
* Remove not needed `apt install`
* Do not deploy on forks

## Reference

fixes #281