### PR TITLE
fix(html): wrong child element

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -23,7 +23,7 @@
             </div>
             {% endfor %}
             <div class="nav-item ml-2 ml-sm-1 text-center">
-              <li class="nav-item dropdown mb-0">
+              <div class="nav-item dropdown mb-0">
                 <button class="nav-link dropdown-toggle" id="navbarDropdown" aria-label="{% t generic.accessibility.lang-menu %}"
                         data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                   <i class="fa fa-globe size-16 color-gray-900"></i><span
@@ -32,7 +32,7 @@
                 <div class="dropdown-menu" aria-labelledby="navbarDropdown">
                   {% include nav_languages.html %}
                 </div>
-              </li>
+              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
Error: Element li not allowed as child of element div in this context. (Suppressing further errors from this subtree.)
Source: Nu Html Checker