### PR TITLE
fix(accessibility): fix missing alt for img

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -4,7 +4,7 @@
 
       <div class="col">
         <a href="/{% if site.lang != 'en' %}{{ site.lang }}{% endif %}">
-          <img src="/assets/branding/logo-full-horizontal-dynamic.svg" id="mainlogo" />
+          <img src="/assets/branding/logo-full-horizontal-dynamic.svg" id="mainlogo" alt="{% t generic.accessibility.logo %}">
         </a>
       </div>
 


### PR DESCRIPTION
Error: An img element must have an alt attribute, except under certain conditions.
Source: Nu Html Checker