### PR TITLE
Check links on generated page, once a month

### DIFF
--- a/.github/workflows/autoreview.yml
+++ b/.github/workflows/autoreview.yml
@@ -11,15 +11,6 @@ jobs:
       with:
         pattern: "*.md"
         locale: "US"
-  checklinks:
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v4
-      - name: Link Checker
-        uses: lycheeverse/lychee-action@v1.8.0
-        with:
-          args: --verbose './**/*.md' 
-          fail: true
   guids:
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -1,0 +1,30 @@
+name: links
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * 0"
+
+jobs:
+  linkChecker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: sudo apt-get install ruby-full build-essential zlib1g-dev git
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2.0'
+      - run: gem install bundler jekyll --no-document
+      - run: bundle install
+      - run: bundle exec jekyll build
+      - name: Link Checker
+        id: lychee
+        uses: lycheeverse/lychee-action@v1.8.0
+        with:
+          args: --verbose --max-concurrency 1 --retry-wait-time 30 --exclude-mail './_site/**/*.html'
+      - name: Create Issue From File
+        if: env.lychee_exit_code != 0
+        uses: peter-evans/create-issue-from-file@v4
+        with:
+          title: Link Checker Report
+          content-filepath: ./lychee/out.md
+          labels: bug

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,3 +1,4 @@
 https://forum.antennapod.org
 http://llama.location.profiles
 https:\/\/(www\.)?twitter\.com\/antennapod
+https:\/\/twitter.com/intent/tweet.*

--- a/_blog/2020-09-29-Version 2 changelog.md
+++ b/_blog/2020-09-29-Version 2 changelog.md
@@ -2,7 +2,7 @@
 title: Version 2.0 Changelog
 excerpt: AntennaPod version 2 released with a range of new features
 date: "2020-09-29 12:00:00"
-image: "pic.png"
+image: "2020/default.png"
 author: keunes
 layout: blog
 unlisted: true

--- a/_i18n/en/documentation/general/external-storage.md
+++ b/_i18n/en/documentation/general/external-storage.md
@@ -1,7 +1,7 @@
-You can set AntennaPod to download episodes to your sd card instead of the internal memory. This ensures that you have more space for episodes. To select the storage card, go to `Settings` » `Storage` » `Data folder`.
+You can set AntennaPod to download episodes to your sd card instead of the internal memory. This ensures that you have more space for episodes. To select the storage card, go to `Settings` » `Downloads` » `Data folder`.
 
 ## Troubleshooting
 
 It might be possible that your SD card does not show up in the `Choose Data Folder` dialog. For your SD card to show up, Android must recognize the card as external storage. Either the card is not mounted correctly or your smartphone manufacturer configured the hardware incorrectly.
 
-If you are running Android 6+ (Marshmallow or newer), you can try [formatting](https://lmgtfy.com/?q=android+6+sd+card+internal+storage) the SD card as internal storage. Else, there is nothing we can do to fix this.
+If you are running Android 6+ (Marshmallow or newer), you can try formatting the SD card as internal storage. Else, there is nothing we can do to fix this.


### PR DESCRIPTION
Having all PRs fail by default looks kind of bad and defeats the whole purpose of having the checks.

Also check the links on the generated page, not the Markdown, to catch all (dynamic) links. Also fixes 2 links.

Fixes #282