### PR TITLE
Update procedure for Google Podcasts migration

### DIFF
--- a/_blog/2023-11-26-google podcasts migration.md
+++ b/_blog/2023-11-26-google podcasts migration.md
@@ -33,7 +33,7 @@ Also, if you were using the Google app solely because of Google Podcasts, note t
 
 We can promise you won’t need to do that. Here is how to export all your subscriptions and automatically add them to AntennaPod:
 
-1. Export your Google Podcasts data in OPML format: you can do this directly from your phone, via the Export Subscriptions screen in Google Podcasts or, alternatively, by visiting [takeout.google.com](https://takeout.google.com) and selecting Google Podcasts.
+1. Export your Google Podcasts data in OPML format: you can do this directly from your phone, via the Export Subscriptions screen in Google Podcasts, or, alternatively, by visiting [takeout.google.com](https://takeout.google.com) and selecting Google Podcasts.
 2. If necessary, copy the OPML file to your phone (or send it to yourself via email).
 3. Finally, open AntennaPod’s settings > Import/Export > “OPML import” and select your OPML file.
 

--- a/_blog/2023-11-26-google podcasts migration.md
+++ b/_blog/2023-11-26-google podcasts migration.md
@@ -33,8 +33,8 @@ Also, if you were using the Google app solely because of Google Podcasts, note t
 
 We can promise you won’t need to do that. Here is how to export all your subscriptions and automatically add them to AntennaPod:
 
-1. Visit [takeout.google.com](https://takeout.google.com) and select Google Podcasts to export your Google Podcasts data in OPML format.
-2. Once you have downloaded your zip archive from Google, locate the OPML file and copy it to your phone (or send it to yourself via email).
+1. Export your Google Podcasts data in OPML format: you can do this directly from your phone, via the Export Subscriptions screen in Google Podcasts or, alternatively, by visiting [takeout.google.com](https://takeout.google.com) and selecting Google Podcasts.
+2. If necessary, copy the OPML file to your phone (or send it to yourself via email).
 3. Finally, open AntennaPod’s settings > Import/Export > “OPML import” and select your OPML file.
 
 Your subscriptions will automatically become available in AntennaPod.


### PR DESCRIPTION
As reported on the [forum](https://forum.antennapod.org/t/can-i-bring-google-podcasts-over-since-they-are-going-away/3808/3), Google now offers a simpler way to export subscriptions in OPML format, so I updated the blog post.