### PR TITLE
chore(dep): pin dependencies to jekyll 4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,19 +1,19 @@
 source "https://rubygems.org"
 
-gem "jekyll"
-gem "jekyll-watch"
+gem "jekyll", "~> 4"
+# jekyll plugins
 gem "jekyll-mentions"
 gem "jekyll-multiple-languages-plugin"
-gem "kramdown"
-gem "webrick"
 
-# Windows and JRuby does not include zoneinfo files, so bundle the tzinfo-data gem
-# and associated library.
+# Windows and JRuby does not include zoneinfo files, so bundle the tzinfo-data gem and associated library.
 platforms :mingw, :x64_mingw, :mswin, :jruby do
-  gem "tzinfo", "~> 1.2"
+  gem "tzinfo", ">= 1", "< 3"
   gem "tzinfo-data"
 end
 
 # Performance-booster for watching directories on Windows
 gem "wdm", "~> 0.1.1", :platforms => [:mingw, :x64_mingw, :mswin]
+
+# Lock `http_parser.rb` gem to `v0.6.x` on JRuby builds since newer versions of the gem do not have a Java counterpart.
+gem "http_parser.rb", "~> 0.6.0", :platforms => [:jruby]
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,33 +1,41 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.0.6)
+    activesupport (7.1.2)
+      base64
+      bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (>= 0.7, < 2)
-      minitest (~> 5.1)
-      tzinfo (~> 1.1)
-      zeitwerk (~> 2.2, >= 2.2.2)
-    addressable (2.8.1)
+      connection_pool (>= 2.2.5)
+      drb
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      mutex_m
+      tzinfo (~> 2.0)
+    addressable (2.8.6)
       public_suffix (>= 2.0.2, < 6.0)
+    base64 (0.2.0)
+    bigdecimal (3.1.5)
     colorator (1.1.0)
-    concurrent-ruby (1.1.10)
+    concurrent-ruby (1.2.2)
+    connection_pool (2.4.1)
+    drb (2.2.0)
+      ruby2_keywords
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
     eventmachine (1.2.7)
-    eventmachine (1.2.7-x64-mingw32)
-    ffi (1.15.5)
-    ffi (1.15.5-x64-mingw32)
+    ffi (1.16.3)
+    ffi (1.16.3-x64-mingw-ucrt)
     forwardable-extended (2.6.0)
-    google-protobuf (3.21.12)
-    google-protobuf (3.21.12-x64-mingw32)
+    google-protobuf (3.25.1-x64-mingw-ucrt)
+    google-protobuf (3.25.1-x86_64-linux)
     html-pipeline (2.14.3)
       activesupport (>= 2)
       nokogiri (>= 1.4)
     http_parser.rb (0.8.0)
-    i18n (1.12.0)
+    i18n (1.14.1)
       concurrent-ruby (~> 1.0)
-    jekyll (4.3.1)
+    jekyll (4.3.3)
       addressable (~> 2.4)
       colorator (~> 1.0)
       em-websocket (~> 0.5)
@@ -61,55 +69,49 @@ GEM
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.4.0)
-    mini_portile2 (2.8.1)
-    minitest (5.17.0)
-    nokogiri (1.14.0)
-      mini_portile2 (~> 2.8.0)
+    minitest (5.20.0)
+    mutex_m (0.2.0)
+    nokogiri (1.16.0-x64-mingw-ucrt)
       racc (~> 1.4)
-    nokogiri (1.14.0-x64-mingw32)
+    nokogiri (1.16.0-x86_64-linux)
       racc (~> 1.4)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
-    public_suffix (5.0.1)
-    racc (1.6.2)
-    rake (13.0.6)
+    public_suffix (5.0.4)
+    racc (1.7.3)
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    rexml (3.2.5)
-    rouge (4.0.1)
+    rexml (3.2.6)
+    rouge (4.2.0)
+    ruby2_keywords (0.0.5)
     safe_yaml (1.0.5)
-    sass-embedded (1.57.1)
-      google-protobuf (~> 3.21)
-      rake (>= 10.0.0)
-    sass-embedded (1.57.1-x64-mingw32)
-      google-protobuf (~> 3.21)
+    sass-embedded (1.69.7-x64-mingw-ucrt)
+      google-protobuf (~> 3.25)
+    sass-embedded (1.69.7-x86_64-linux-gnu)
+      google-protobuf (~> 3.25)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
-    thread_safe (0.3.6)
-    tzinfo (1.2.10)
-      thread_safe (~> 0.1)
-    tzinfo-data (1.2022.7)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
+    tzinfo-data (1.2023.4)
       tzinfo (>= 1.0.0)
-    unicode-display_width (2.4.2)
+    unicode-display_width (2.5.0)
     wdm (0.1.1)
-    webrick (1.7.0)
-    zeitwerk (2.6.6)
+    webrick (1.8.1)
 
 PLATFORMS
-  ruby
-  x64-mingw32
+  x64-mingw-ucrt
+  x86_64-linux
 
 DEPENDENCIES
-  jekyll
+  http_parser.rb (~> 0.6.0)
+  jekyll (~> 4)
   jekyll-mentions
   jekyll-multiple-languages-plugin
-  jekyll-watch
-  kramdown
-  tzinfo (~> 1.2)
+  tzinfo (>= 1, < 3)
   tzinfo-data
   wdm (~> 0.1.1)
-  webrick
 
 BUNDLED WITH
-   2.2.17
+   2.4.10

--- a/_config.yml
+++ b/_config.yml
@@ -11,7 +11,6 @@ mastodon_username: AntennaPod
 mastodon_server: fosstodon.org
 
 # Build settings
-markdown: kramdown
 future: true
 
 plugins:


### PR DESCRIPTION
## Change

- Pin dependencies to jekyll 4
- Remove already satisfied dependencies. (`jekyll-watch`, `kramdown` and `webrick` are covered by `jekyll`)
- Remove default config.
- Update JRuby dependencies according to current jekyll template.

