### PR TITLE
Fix JavaScript on subscribe page

### DIFF
--- a/deeplink/subscribe/index.html
+++ b/deeplink/subscribe/index.html
@@ -25,28 +25,22 @@ title: generic.subscribe
 </div>
 
 <script>
-  const getUrlParameter = (sParam) => {
-    const paramValue = new URLSearchParams(window.location.search.substring(1)).get(sParam) ?? "";
-    if (0 < paramValue.length) {
-      return decodeURIComponent(paramValue);
-    }
-    return false;
-  };
-
+  const urlParams = new URLSearchParams(window.location.search.substring(1));
   const urlTextBox = document.getElementById("urlTextBox");
   const subscribeButton = document.getElementById("subscribeButton");
   const podcastTitle = document.getElementById("podcastTitle");
-  if (getUrlParameter("url") === false) {
+  if (!urlParams.has("url")) {
     urlTextBox.textContent = "URL not available";
     subscribeButton.disabled = true;
     subscribeButton.textContent += " (error)";
   } else {
-    if (getUrlParameter("title") !== false) {
-      podcastTitle.textContent = getUrlParameter("title");
+    if (urlParams.has("title")) {
+      podcastTitle.textContent = urlParams.get("title");
     }
-    urlTextBox.textContent = getUrlParameter("url");
+    const url = urlParams.get("url");
+    urlTextBox.textContent = url;
     subscribeButton.onclick = () => {
-      window.open("antennapod-subscribe://" + getUrlParameter("url"));
+      window.open("antennapod-subscribe://" + url);
     };
   }
 </script>


### PR DESCRIPTION
URLSearchParams already decodes the text.
So if there is a percentage sign in the title, it tried to decode it twice.

Closes https://github.com/AntennaPod/antennapod.github.io/issues/331