### PR TITLE
Add documentation articles

### DIFF
--- a/_documentation/bugs-first-aid/cannot-resume-playback.md
+++ b/_documentation/bugs-first-aid/cannot-resume-playback.md
@@ -1,0 +1,12 @@
+---
+title: documentation.categories.bugs-first-aid.cannot-resume-playback
+layout: doc
+level: "2"
+group: "bugs-first-aid"
+icon: "fa-solid fa-pause"
+order: 06
+---
+
+# {% t {{ page.title }} %}
+
+{% tf documentation/{{ page.group }}/{{ page.slug }}.md %}

--- a/_documentation/podcasters-hosters/update-feed-urls.md
+++ b/_documentation/podcasters-hosters/update-feed-urls.md
@@ -1,0 +1,11 @@
+---
+title: documentation.categories.podcasters-hosters.update-feed-urls
+layout: doc
+level: "2"
+group: "podcasters-hosters"
+icon: "fa-solid fa-arrow-right-arrow-left"
+---
+
+# {% t {{ page.title }} %}
+
+{% tf documentation/{{ page.group }}/{{ page.slug }}.md %}

--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -178,11 +178,13 @@ documentation:
       episodes-missing: "Old episodes are missing"
       playback-stops: "Playback suddenly stops"
       refresh-download-errors: "Download or feed refresh error"
+      cannot-resume-playback: "Can't resume playback from lock screen / notification"
     podcasters-hosters:
       title: "For Podcasters & Hosters"
       intro: "Below, you can find our support information for podcasters & hosting providers."
       add-on-antennapod: "Create an 'Open in AntennaPod' link"
       list-podcast: "Getting your podcast listed"
+      update-feed-urls: "Updating feed URLs"
 
 ## Events
 events:

--- a/_i18n/en/documentation/bugs-first-aid/cannot-resume-playback.md
+++ b/_i18n/en/documentation/bugs-first-aid/cannot-resume-playback.md
@@ -1,0 +1,13 @@
+In Android 13 and Android 14 it is not always possible to resume playback from the lock screen or media notification. This occurs specifically if playback has been paused for a while.
+
+It currently is not clear why this issue occurs. We have established the same problem affects other apps, including Google's apps. We suspect, therefore, that this is an issue with Android.
+
+## Workaround
+
+In order to still be able to resume playback, you can add the so-called AntennaPod 'tile' on your device. Tiles are essentially the buttons that you see when you pull down from the top of the screen. You probably know the Internet or Flashlight tile. The AntennaPod tile allows you play and pause playback, even if playback has been paused for a while.
+
+To add the AntennaPod tile:
+1. **Pull down twice** from the top of the screen, so you see the full buttons (below the brightness indicator)
+2. **Tap on the pencil icon** at the bottom of the tiles section to edit the tiles
+3. Scroll down the list of tiles, **tap on the AntennaPod tile and drag it** up into the list of active tiles
+4. Tap the back arrow to exit the tile editing

--- a/_i18n/en/documentation/podcasters-hosters/update-feed-urls.md
+++ b/_i18n/en/documentation/podcasters-hosters/update-feed-urls.md
@@ -1,4 +1,4 @@
-When you change hoster, the URL of your RSS feed often changes as well. In this situation, we strongly recommend that you organise a proper 'redirect' from the old to the new feed with either of these HTTP response status codes:
+When you change hoster, the URL of your RSS feed often changes as well. In this situation, we strongly recommend that you organize a proper 'redirect' from the old to the new feed with either of these HTTP response status codes:
 * [301 Moved Permanently](https://developer.mozilla.org/docs/Web/HTTP/Status/301)
 * [308 Permanent Redirect](https://developer.mozilla.org/docs/Web/HTTP/Status/308)
 

--- a/_i18n/en/documentation/podcasters-hosters/update-feed-urls.md
+++ b/_i18n/en/documentation/podcasters-hosters/update-feed-urls.md
@@ -1,0 +1,7 @@
+When you change hoster, the URL of your RSS feed often changes as well. In this situation, we strongly recommend that you organise a proper 'redirect' from the old to the new feed with either of these HTTP response status codes:
+* [301 Moved Permanently](https://developer.mozilla.org/docs/Web/HTTP/Status/301)
+* [308 Permanent Redirect](https://developer.mozilla.org/docs/Web/HTTP/Status/308)
+
+This way you make sure that AntennaPod users get this change applied in their app. Your audience will then continue to receive your episodes, without having to subscribe again to the new feed.
+
+Don't forget also to update your entry in [the directories](/documentation/podcasters-hosters/list-podcast) AntennaPod uses for its search functionality.


### PR DESCRIPTION
* Bugs/First aid: can't resume from notification & workaround
* Podcasters: update feed URLs

Addresses https://github.com/AntennaPod/AntennaPod/issues/6915 & puts https://github.com/AntennaPod/AntennaPod/wiki/Updated-feed-URLs-%28301-or-308-redirects%29 together with other documentation for podcast publishers.