### PR TITLE
Update class name for integration with other apps

### DIFF
--- a/_i18n/en/documentation/automation/tasker.md
+++ b/_i18n/en/documentation/automation/tasker.md
@@ -7,21 +7,21 @@ If you have more complex needs, you can use various 3rd-party automation applica
 ## General instructions
 In your automation application, you can get AntennaPod to update its subscriptions by sending a 'Broadcast' (it may be shown as a type of Android intent) with the following settings:
 - Package name: `de.danoeh.antennapod`
-- Class name: `de.danoeh.antennapod.core.receiver.FeedUpdateReceiver`
+- Class name: `de.danoeh.antennapod.net.download.service.feed.FeedUpdateReceiver`
 
 ## Steps for some automation apps
 
 ### Automate ([website](https://llamalab.com/automate/))
 In a flow, add a block of the type `APPS` » `Broadcast send` and specify
 1. Package to be `de.danoeh.antennapod`
-2. Receiver class to be `de.danoeh.antennapod.core.receiver.FeedUpdateReceiver`
+2. Receiver class to be `de.danoeh.antennapod.net.download.service.feed.FeedUpdateReceiver`
 
 ### Tasker ([website](https://tasker.joaoapps.com/))
 Create a task. In the task, add an action
 1. Select `System`
 2. Select `Send Intent`
 3. Specify Package name to be `de.danoeh.antennapod`
-4. Specify Class name to be `de.danoeh.antennapod.core.receiver.FeedUpdateReceiver`
+4. Specify Class name to be `de.danoeh.antennapod.net.download.service.feed.FeedUpdateReceiver`
 5. Specify Target to be `Broadcast receiver`
 6. You can leave the other fields blank
 
@@ -30,7 +30,7 @@ Create an event (Llama automation rule). In the event,
 1. Add an action of type Android intent.
 2. Specify Intent send mode to be `Broadcast`.
 3. Specify Package name to be `de.danoeh.antennapod`
-4. Specify Class name to be `de.danoeh.antennapod.core.receiver.FeedUpdateReceiver`
+4. Specify Class name to be `de.danoeh.antennapod.net.download.service.feed.FeedUpdateReceiver`
 5. Add any other condition / actions for your specific needs.
 
 As a shortcut, you can click [this link](http://llama.location.profiles/AntennaPod+feeds+Update/AntennaPod+feeds+Update%7C0-1-0-0-0-0-0-0-1-0--0-%7C%3A%7Ct%7C420%7C425%7Cai%7Cde.danoeh.antennapod%7CFgAAAGEAbgBkAHIAbwBpAGQALgBjAG8AbgB0AGUAbgB0AC4ASQBuAHQAZQBuAHQAAAAAAP%2F%2F%2F%2F8AAAAA%2F%2F%2F%2F%2FwAAAAD%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FxQAAABkAGUALgBkAGEAbgBvAGUAaAAuAGEAbgB0AGUAbgBuAGEAcABvAGQAAAAAADUAAABkAGUALgBkAGEAbgBvAGUAaAAuAGEAbgB0AGUAbgBuAGEAcABvAGQALgBjAG8AcgBlAC4AcgBlAGMAZQBpAHYAZQByAC4ARgBlAGUAZABVAHAAZABhAHQAZQBSAGUAYwBlAGkAdgBlAHIAAAAAAAAAAAAAAAAAAAAAAAAA%2Fv%2F%2F%2F%2F%2F%2F%2F%2F8%3D%7C2%7C) to create an example event to get started.


### PR DESCRIPTION
Fixes #347.

I assume we don't need to keep the information for older versions (we can always point users to an archived copy of the page if needed).