### PR TITLE
Fix outdated contribute section

### DIFF
--- a/_i18n/en/contribute/develop.md
+++ b/_i18n/en/contribute/develop.md
@@ -4,9 +4,7 @@ As a community project, AntennaPod relies on voluntary code contributions from a
 You're right at it: the core of the project! Used by thousands of people across the world, your contributions are an important contribution to an open podcasting ecosystem. So, are you experienced with Java, or just getting started? We welcome your contributions in our [GitHub repository](https://github.com/AntennaPod/AntennaPod).
 
 ## Where we need help
-There's a few areas where we could well use your support. Because they're important, often-requested, or both. We've set up a clear overview of [the issues and feature areas we most need help with](https://github.com/AntennaPod/AntennaPod/projects/2). Get yourself into any of the following issues and we'll add you to our (mental) list for eternal gratitude!
-
-Apart from these major projects, you can always check out the [issues with the 'help wanted' label](https://github.com/AntennaPod/AntennaPod/labels/help%20wanted) on GitHub.
+There's a few areas where we could well use your support. When first getting started to AntennaPod development, we recommend to pick an issue with the ['Good first issue' label](https://github.com/AntennaPod/AntennaPod/labels/Good%20first%20issue) on GitHub. Before you start working on an issue, make sure that it does not have the 'Needs: Triage' or 'Needs: Decision' label. That label means that the feature was not reviewed by the core AntennaPod team yet.
 
 If you prefer bug-hunting, your go-to list for a weekend bug-hunt is the ['confirmed bugs' issue label](https://github.com/AntennaPod/AntennaPod/labels/Type%3A%20Confirmed%20bug) on GitHub.
 


### PR DESCRIPTION
GitHub removed the old project boards after the new project boards were on beta for a long time. Because we did not use/update the board anyway, I just removed the broken link. I also fixed the issue label

Closes #359