### PR TITLE
Add Home screen to documentation

### DIFF
--- a/_documentation/getting-started/home.md
+++ b/_documentation/getting-started/home.md
@@ -1,0 +1,12 @@
+---
+title: documentation.categories.getting-started.home
+layout: doc
+level: "2"
+group: "getting-started"
+icon: "fa-solid fa-house"
+order: "20"
+---
+
+# {% t {{ page.title }} %}
+
+{% tf documentation/{{ page.group }}/{{ page.slug }}.md %}

--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -138,6 +138,7 @@ documentation:
       title: "Getting started"
       intro: "Welcome to AntennaPod! Below, you can find some details on how to get started with AntennaPod."
       subscribe: "Subscribing to a podcast"
+      home: "Using the Home screen"
     general:
       title: "General"
       intro: "Below, you can find more details about the AntennaPod project."

--- a/_i18n/en/documentation/getting-started/home.md
+++ b/_i18n/en/documentation/getting-started/home.md
@@ -1,0 +1,20 @@
+The Home screen, introduced in AntennaPod 3.0, brought about a new way to have a quick overview of your podcasts, start listening and perform a range of actions.
+
+It contains five sections, each of which displays episodes to interact with directly, but also provides a shortcut to the related screen (e.g. your queue):
+
+## Continue listening
+This section allows you to quickly and easily carry on listening to episodes you already have in your queue, beginning with those you have already started listening to, but haven’t finished just yet.
+
+## See what’s new
+In this section, you will find the latest episodes that have landed in your inbox as a result of having refreshed your subscriptions.
+
+## Get surprised
+Here you can find a random selection of episodes from your subscriptions you haven’t listened to yet. If you don’t see anything you feel like listening, you can tap the arrow button to refresh the selection.
+
+## Check your classics
+Here you can quickly see and get access to your all-time most-listened subscriptions.
+
+## Manage downloads
+In this section, you can interact with the episodes you downloaded on your device.
+
+You can customise your Home screen – that is, reorder these sections or hide some of them – by tapping `…` in the top bar and selecting `Configure Home Screen`.

--- a/_i18n/en/documentation/getting-started/home.md
+++ b/_i18n/en/documentation/getting-started/home.md
@@ -1,6 +1,4 @@
-The Home screen, introduced in AntennaPod 3.0, brought about a new way to have a quick overview of your podcasts, start listening and perform a range of actions.
-
-It contains five sections, each of which displays episodes to interact with directly, but also provides a shortcut to the related screen (e.g. your queue):
+The Home screen allows you to have a quick overview of your podcasts, start listening and perform a range of actions, all conveniently from the same screen. It contains five sections, each of which displays episodes or subscriptions to interact with directly, but also provides a shortcut to the related screen (e.g. your queue):
 
 ## Continue listening
 This section allows you to quickly and easily carry on listening to episodes you already have in your queue, beginning with those you have already started listening to, but haven’t finished just yet.

--- a/_i18n/en/documentation/getting-started/home.md
+++ b/_i18n/en/documentation/getting-started/home.md
@@ -1,4 +1,7 @@
-The Home screen allows you to have a quick overview of your podcasts, start listening and perform a range of actions, all conveniently from the same screen. It contains five sections, each of which displays episodes or subscriptions to interact with directly, but also provides a shortcut to the related screen (e.g. your queue):
+The Home screen allows you to have a quick overview of your podcasts, start listening and perform a range of actions, all conveniently from the same screen.
+
+It contains five sections, each of which displays episodes or subscriptions to interact with directly, but also provides a shortcut to the related screen (e.g. your queue).
+You can customize your Home screen – that is, reorder these sections or hide some of them – by tapping `…` in the top bar and selecting `Configure Home Screen`.
 
 ## Continue listening
 This section allows you to quickly and easily carry on listening to episodes you already have in your queue, beginning with those you have already started listening to, but haven’t finished just yet.
@@ -14,5 +17,3 @@ Here you can quickly see and get access to your all-time most-listened subscript
 
 ## Manage downloads
 In this section, you can interact with the episodes you downloaded on your device.
-
-You can customise your Home screen – that is, reorder these sections or hide some of them – by tapping `…` in the top bar and selecting `Configure Home Screen`.


### PR DESCRIPTION
Closes #278.

Largely based on the [blog post](https://antennapod.org/blog/2023/05/introducing-the-home-screen) from 2023, but with the advantage of being searchable from within the documentation.