### PR TITLE
Fix subscribe deeplink

### DIFF
--- a/deeplink/subscribe/index.html
+++ b/deeplink/subscribe/index.html
@@ -41,7 +41,7 @@ excerpt: generic.subscribe-subtitle
     const url = urlParams.get("url");
     urlTextBox.textContent = url;
     subscribeButton.onclick = () => {
-      window.open("antennapod-subscribe://" + url);
+      window.open("antennapod-subscribe://" + url.replace(/^https?:\/\//g, ''));
     };
   }
 </script>


### PR DESCRIPTION
A colon inside the protocol is not a valid url.

The website tried to open `antennapod-subscribe://https://abc` but ended up opening `antennapod-subscribe://https//abc`, which caused an error.

Now the website strips the http(s) and gives `antennapod-subscribe://abc` and the app adds the protocol.