### PR TITLE
Minor improvements to Contribute and Documentation sections

### DIFF
--- a/_contribute/test.md
+++ b/_contribute/test.md
@@ -2,7 +2,7 @@
 layout: redirect
 level: 1
 texts: contribute.test
-icon: "fa-solid fa-bullhorn"
+icon: "fa-solid fa-flask-vial"
 order: "30"
 redirect_to: /documentation/general/beta
 ---

--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -141,7 +141,7 @@ contribute:
 
 ## Documentation
 documentation:
-  intro: "Welcome to the documentation section of the AntennaPod. This section aims to provide information on current features."
+  intro: "Welcome to the documentation section of AntennaPod. This section aims to provide information on current features."
   search:
     placeholder: "Search documentation"
     no-results: "Sorry, nothing found"
@@ -231,7 +231,7 @@ documentation:
     cannot-resume-playback:
       title: "Can't resume playback from lock screen / notification"
   podcasters-hosters:
-    title: "For Podcasters & Hosters"
+    title: "For podcasters & hosters"
     intro: "Below, you can find our support information for podcasters & hosting providers."
     add-on-antennapod:
       title: "Create an 'Open in AntennaPod' link"


### PR DESCRIPTION
Three small improvements identified while working on another PR:
1. Differentiate the icon used for the Test card from the Promote one
2. Address a typo in the Documentation index
3. Correct the capitalisation of a documentation section