### PR TITLE
Exclude all _i18n subfolders except 'en' from spellcheck

### DIFF
--- a/.github/workflows/autoreview.yml
+++ b/.github/workflows/autoreview.yml
@@ -11,6 +11,7 @@ jobs:
       with:
         pattern: "*.md"
         locale: "US"
+        exclude: "./_i18n/!(en)/**"
   guids:
     runs-on: ubuntu-22.04
     steps:


### PR DESCRIPTION
Similar words in other languages cause false positives: https://github.com/AntennaPod/antennapod.github.io/pull/363/checks?check_run_id=42034626269