### PR TITLE
docs: automation: correct information in refreshing-podcasts.md

### DIFF
--- a/_i18n/en/documentation/automation/refreshing-podcasts.md
+++ b/_i18n/en/documentation/automation/refreshing-podcasts.md
@@ -1,4 +1,4 @@
-By default, all podcasts are refreshed with a 12-hour interval to pick up new episodes. Via `Settings` » `Network` » `Refresh podcasts` you can change the interval period or turn off the automatic updates.
+By default, all podcasts are refreshed with a 12-hour interval to pick up new episodes. Via `Settings` » `Downloads` » `Refresh podcasts` you can change the interval period or turn off the automatic updates.
 
 You can also turn off this process for individual podcasts in case keeping a podcast up to date is unnecessary. You can use this, for example, if a podcast no longer releases new episodes. Alternatively, there might be a podcast of which you only want to listen to an episode occasionally. You can set this by going to a podcast, tapping on the `Gear` icon and changing the `Keep Updated` setting.
 


### PR DESCRIPTION
In this commit I correct a small inconsistency between what's in the documentation and what I encounter in the actual app. I'm on 3.9.0f downloaded from F-droid.