### PR TITLE
Fix typo in automation instructions

### DIFF
--- a/_i18n/en/documentation/automation/tasker.md
+++ b/_i18n/en/documentation/automation/tasker.md
@@ -12,7 +12,7 @@ In your automation application, you can get AntennaPod to update its subscriptio
 ## Steps for some automation apps
 
 ### HomeAssistant Android Mobile Companion ([website](https://companion.home-assistant.io/docs/notifications/notification-commands/#broadcast-intent))
-Create a notify action call in a automation with the following template:
+Create a notify action call in an automation with the following template:
 ```
 action: notify.mobile_app_<SOME-ANDROID-MOBILE-DEVICE>
 metadata: {}


### PR DESCRIPTION
Fix a typo spotted while translating.