### PR TITLE
 Update Documentation (deletion/storage)

### DIFF
--- a/_i18n/en/documentation/automation/deletion.md
+++ b/_i18n/en/documentation/automation/deletion.md
@@ -2,8 +2,8 @@ Why are some downloaded episodes deleted?
 
 AntennaPod has several mechanisms to make sure downloaded podcasts will not fill up your phone's memory. If you notice some downloaded episodes being deleted, have a look at these two settings:
 
-## Auto Delete
-Auto Delete is located in `Settings` » `Storage`. When enabled, episodes are deleted when playback completes (but not when manually marking an episode as 'played').
+## Delete after playing
+Delete after playing is located in `Settings` » `Downloads` » `Automatic deletion`. When enabled, episodes are deleted when playback completes (but not when manually marking an episode as 'played').
 
-## Episode Cleanup
-Episode Cleanup is located in `Settings` » `Network` » `Automatic Download`. If Automatic Download needs space for new episodes, it will delete old episodes that are not in the queue and not marked as favorite. You can add a delay (x time after playback) or Episode. The setting `Episode Cache` determines the maximum amount of downloaded episodes.
+## Delete before auto download
+Delete before auto download is located in `Settings` » `Downloads` » `Automatic deletion`. If Automatic download needs space for new episodes, it will delete old episodes that are not in the queue and not marked as favorite. You can set which episodes are eligible for deletion based on their status (e.g. not favorited or not in queue) or a period of time after finishing.


### PR DESCRIPTION
**Disclaimer:** It's my first PR, so I'd really appreciate feedback here.

I came across some inaccurate instructions when I was translating website components earlier today and I thought I'd give it a try with my first pull request. 
This is about some information that might be outdated, which I guess were a collateral effect from app’s UX reworks. It includes incorrect _paths_ to settings _option names_. There are a couple of them.

[Automatic deletion](https://antennapod.org/documentation/automation/deletion) page:
> Auto Delete is located in `Settings` » `Storage`

In fact, the **`Automatic deletion`** (renamed) option is located under `Settings` » `Downloads` nowadays. The same page still mentions outdated resources such as `Episode Cleanup` also with incorrect paths.

[All my podcasts & episodes are gone](https://antennapod.org/documentation/bugs-first-aid/database-error) & [Backing up your episodes](https://antennapod.org/documentation/general/backup) pages:
> `Settings` » `Storage` » `Import/Export` » `Database import`

When it should be:
> `Settings` » `Import/Export` » `Database import`