### PR TITLE
fix: GitHub labels filters flickering (AntennaPod#452)

### DIFF
--- a/_contribute/design.md
+++ b/_contribute/design.md
@@ -4,5 +4,5 @@ level: 1
 texts: contribute.design
 icon: "fa-solid fa-pen-ruler"
 order: "60"
-external_redirect: https://github.com/AntennaPod/AntennaPod/labels/%22needs:%20mock-up%20or%20user%20story%22
+external_redirect: https://github.com/AntennaPod/AntennaPod/issues?q=state%3Aopen%20label%3A%22Needs%3A%20Mock-up%20or%20user%20story%22
 ---

--- a/_events/needs-decision.md
+++ b/_events/needs-decision.md
@@ -20,7 +20,7 @@ recurrence-additions:
 - start: 2024-07-10 21:00
   end: 2024-07-10 22:30
 location: online
-more-information: https://github.com/AntennaPod/AntennaPod/labels/%22Needs%3A%20decision%22
+more-information: https://github.com/AntennaPod/AntennaPod/issues?q=state%3Aopen%20label%3A%22Needs%3A%20Decision%22
 meeting-room: https://meet.antennapod.org/needsdecision
 ---
 
@@ -28,4 +28,4 @@ We are very careful about AntennaPod's User Experience (UX). The [project's goal
 
 Where do we place this button? What would most users expect AntennaPod to do here? Which impact does this choice have on other settings? How can we implement this without making the UI or code complex?
 
-In these meetings @ByteHamster and @Keunes get together to do just that: discuss the options for a given feature request, and try to reach a decision. One [issue](https://github.com/AntennaPod/AntennaPod/labels/%22Needs%3A%20decision%22) at a time. You're most welcome to listen in as a fly on the wall, or jump in and share your thoughts.
+In these meetings @ByteHamster and @Keunes get together to do just that: discuss the options for a given feature request, and try to reach a decision. One [issue](https://github.com/AntennaPod/AntennaPod/issues?q=state%3Aopen%20label%3A%22Needs%3A%20Decision%22) at a time. You're most welcome to listen in as a fly on the wall, or jump in and share your thoughts.

--- a/_i18n/en/contribute/develop/app.md
+++ b/_i18n/en/contribute/develop/app.md
@@ -1,9 +1,9 @@
 You're right at it: the core of the project! Used by thousands of people across the world, your contributions are an important contribution to an open podcasting ecosystem. So, are you experienced with Java, or just getting started? We welcome your contributions in our [GitHub repository](https://github.com/AntennaPod/AntennaPod).
 
 ## Where we need help
-There are a few areas where we could well use your support. When first getting started to AntennaPod development, we recommend to pick an issue with the ['Good first issue' label](https://github.com/AntennaPod/AntennaPod/labels/%22Good%20first%20issue%22) on GitHub. Before you start working on an issue, make sure that it does not have the 'Needs: Triage' or 'Needs: Decision' label. Those labels mean that the feature was not reviewed by the core AntennaPod team yet.
+There are a few areas where we could well use your support. When first getting started to AntennaPod development, we recommend to pick an issue with the ['Good first issue' label](https://github.com/AntennaPod/AntennaPod/issues?q=state%3Aopen%20label%3A%22Good%20first%20issue%22) on GitHub. Before you start working on an issue, make sure that it does not have the 'Needs: Triage' or 'Needs: Decision' label. Those labels mean that the feature was not reviewed by the core AntennaPod team yet.
 
-If you prefer hunting bugs, your go-to list for a weekend bug-hunt is the ['confirmed bugs' issue label](https://github.com/AntennaPod/AntennaPod/labels/%22Type%3A%20Confirmed%20bug%22) on GitHub.
+If you prefer hunting bugs, your go-to list for a weekend bug-hunt is the ['confirmed bugs' issue label](https://github.com/AntennaPod/AntennaPod/issues?q=state%3Aopen%20label%3A%22Type%3A%20Confirmed%20bug%22) on GitHub.
 
 ## Getting started
 Before submitting a pull request, always *announce your interest first*. Sometimes we haven't reached an agreement on a user experience and interface yet. Or it can happen that someone volunteered to start working on something, but we forgot to 'assign' the GitHub issue. Chipping in on our [forum](https://forum.antennapod.org) is the best way to avoid losing hours on code that won't be accepted.


### PR DESCRIPTION
Updates GitHub link formats to align with the current GitHub UI.

As discussed in #452, this PR updates the link format to ensure better stability and consistency with the current GitHub UI.

Closes #452 