### PR TITLE
Updated label mentioning where to find the Android Auto settings

### DIFF
--- a/_i18n/en/documentation/playback/android-auto.md
+++ b/_i18n/en/documentation/playback/android-auto.md
@@ -8,7 +8,7 @@ No further steps are required to use AntennaPod in your car. Just connect your p
 
 If you downloaded AntennaPod from F-Droid, further steps are required.
 
-  - Open the Android Auto settings.
+  - Open the Android Auto settings on your phone.
   - Enable `Developer settings` by pressing the version number 10 times.
   - Open the 3-dot menu and launch the developer settings.
   - Enable `Unknown sources`.


### PR DESCRIPTION
Hi,
as mentioned in my issue in #462 I updated the English base translation to add clarity where to find the mentioned "Android Auto settings".

Scouting previous commits I guessed that the English base translation should be updated in the repository when website content changes and other translations are then managed through Weblate.
Correct me if I am wrong on this assumption.

As this is a change to already existing text (and the English text is read-only in Weblate) and no new translation I figured it should be handled this way.
Again, correct me if I am wrong on this assumption.

Have a great day!

Closes https://github.com/AntennaPod/antennapod.github.io/issues/462