### PR TITLE
Refine terminology in beta documentation

### DIFF
--- a/_i18n/en/documentation/general/beta.md
+++ b/_i18n/en/documentation/general/beta.md
@@ -1,11 +1,11 @@
-AntennaPod has many users, and we don't want them to run into trouble because we've tweaked or added a new feature. It's important to have people testing our app. The more people testing, the more combinations of phones, Android versions, and use cases we can cover, and the more issues we can prevent before official releases.
-Of course, this only helps if you report the issues you encounter by creating a thread on [our forum](https://forum.antennapod.org/).
+AntennaPod has many users, and we don't want them to run into trouble because we've tweaked or added a new feature. It's important to have people testing our app. The more people testing, the more combinations of phones, Android versions, and use cases we can cover, and the more issues we can resolve before official releases.
+Of course, this only helps if you report the issues you encounter by creating a topic on [our forum](https://forum.antennapod.org/).
 
 Minor issues often crop up after major updates, and they're usually discovered through bug reports from users in these early stages. There's only one main developer working on this in his spare time. While behavior can greatly vary from one device to another, he only has so many devices to test on.
 
 ## Google Play
 Every new version of AntennaPod is sent to our beta testers through the Google Play Store before being released to the general public. If you have a sharp eye and can explain what's not working quite right, we'd love your help! Plus, when you share your thoughts on what could be improved, you help shape the app to better match what you (and the community) expect.
-Please leave your feedback by creating a thread on [our forum](https://forum.antennapod.org/).
+Please leave your feedback by creating a topic on [our forum](https://forum.antennapod.org/).
 
 So, you want to have the latest and greatest, and help us polish the app to make it truly shine? Simply visit the AntennaPod listing in the Play Store app, and you'll find the **Join the beta** card under the *App support* section. Or, if you're on your computer, you can join our beta program [here](https://play.google.com/apps/testing/de.danoeh.antennapod).
 


### PR DESCRIPTION
Minor improvements identified while translating:

1. Make a sentence more coherent (if a bug is already released to beta, it cannot really be "prevented")
2. Match the term used by Discourse