### PR TITLE
Link index over all documentation pages (for agents)

### DIFF
--- a/_layouts/doc.html
+++ b/_layouts/doc.html
@@ -16,6 +16,12 @@
                     <article class="post-content">
                         {{ content | remove: "<!-- mdpo-disable -->" | remove: "<!-- mdpo-enable -->" | remove: "<!-- mdpo-disable-next-line -->" | remove: "<!-- mdpo-enable-next-line -->" }}
                     </article>
+
+                    <noscript>
+                        <a href="{{ site.url }}{% if site.lang != "en" %}/{{ site.lang }}{% endif %}/assets/datasets/documentation_index.json">
+                            View full machine readable documentation (json)
+                        </a>
+                    </noscript>
                 </div>
             </div>
             
@@ -27,7 +33,6 @@
             {%- endfor %}
             </div>
             {%- endif %}
-            
         </div>
     </div>
     </main>

--- a/documentation/index.html
+++ b/documentation/index.html
@@ -31,6 +31,11 @@ title: titles.documentation
       <div id="results-container" class="doc-search-results"></div>
       <small id="search-help" class="form-text text-body-secondary mt-2 d-block text-center">
         <i class="fa-solid fa-keyboard me-1"></i> {% t documentation.search.hint %}
+        <noscript>
+          <a href="{{ site.url }}{% if site.lang != "en" %}/{{ site.lang }}{% endif %}/assets/datasets/documentation_index.json">
+            View full machine readable documentation (json)
+          </a>
+        </noscript>
       </small>
     </div>
   </div>


### PR DESCRIPTION
Technically this is also visible to users without javascript. For those it is aligned nicely and has a user-readable title. Note that the website doesn't really work without javascript (search broken, language switcher broken), so users have to enable javascript anyway and won't see this then.