### PR TITLE
docs: list self-hosted sync servers with programming languages

### DIFF
--- a/_i18n/de/documentation/general/synchronization.md
+++ b/_i18n/de/documentation/general/synchronization.md
@@ -17,14 +17,7 @@ loc="/assets/images/documentation" file="gpodder-synchronize.png" %} {% endcaptu
 AntennaPod kann deine Abonnements und deinen Hörfortschritt mit anderen AntennaPod-Installationen sowie anderen (Desktop-)Anwendungen synchronisieren. Um die Synchronisierung einzurichten, benötigst du einen Server – den zentralen Punkt, über den deine Daten mit anderen Geräten geteilt werden. Hierfür hast du mehrere Möglichkeiten:
 
 * [gpodder.net](https://gpodder.net/) bietet einen kostenlosen gPodder-Synchronisierungsserver an, für den sich **jeder anmelden kann**. Leider ist dieser Server aufgrund der Beliebtheit des Dienstes und seiner begrenzten Finanzierung oft überlastet, was zu Fehlern in AntennaPod führt.
-* Technisch versierteren Benutzern wird dringend empfohlen, **selbst einen Synchronisierungsserver zu betreiben**. Ein selbst betriebener Server ist zuverlässiger und trägt dazu bei, die Belastung der kostenlosen öffentlichen Dienste zu verringern. Es gibt mehrere Optionen:
-  * [Nextcloud](https://nextcloud.com/install/#instructions-server) mit der [gPodder-Sync-App](https://apps.nextcloud.com/apps/gpoddersync) (PHP)
-  * [oPodSync](https://github.com/kd2org/opodsync) (PHP)
-  * [goPodder](https://github.com/cbrgm/gopodder) (Go)
-  * [podsync](https://github.com/bobrippling/podsync) (Rust)
-  * [malipod](https://github.com/eliassoares/malipod-selfhosted) (Python)
-
-Dies sind Drittanbieterprojekte, die nicht mit AntennaPod in Verbindung stehen.
+* Technisch versierteren Benutzern wird dringend empfohlen, **selbst einen Synchronisierungsserver zu betreiben**. Ein selbst betriebener Server ist zuverlässiger und trägt dazu bei, die Belastung der kostenlosen öffentlichen Dienste zu verringern. Es gibt mehrere Optionen: [Nextcloud](https://nextcloud.com/install/#instructions-server) mit der [gPodder-Sync-App](https://apps.nextcloud.com/apps/gpoddersync), ein vollständiger [gPodder](https://gpoddernet.readthedocs.io/en/latest/dev/installation.html)-Server oder der [Micro-GPodder-Server](https://github.com/bohwaz/micro-gpodder-server).
 
 ## Synchronisierung per Nextcloud aktivieren
 

--- a/_i18n/de/documentation/general/synchronization.md
+++ b/_i18n/de/documentation/general/synchronization.md
@@ -17,7 +17,14 @@ loc="/assets/images/documentation" file="gpodder-synchronize.png" %} {% endcaptu
 AntennaPod kann deine Abonnements und deinen Hörfortschritt mit anderen AntennaPod-Installationen sowie anderen (Desktop-)Anwendungen synchronisieren. Um die Synchronisierung einzurichten, benötigst du einen Server – den zentralen Punkt, über den deine Daten mit anderen Geräten geteilt werden. Hierfür hast du mehrere Möglichkeiten:
 
 * [gpodder.net](https://gpodder.net/) bietet einen kostenlosen gPodder-Synchronisierungsserver an, für den sich **jeder anmelden kann**. Leider ist dieser Server aufgrund der Beliebtheit des Dienstes und seiner begrenzten Finanzierung oft überlastet, was zu Fehlern in AntennaPod führt.
-* Technisch versierteren Benutzern wird dringend empfohlen, **selbst einen Synchronisierungsserver zu betreiben**. Ein selbst betriebener Server ist zuverlässiger und trägt dazu bei, die Belastung der kostenlosen öffentlichen Dienste zu verringern. Es gibt mehrere Optionen: [Nextcloud](https://nextcloud.com/install/#instructions-server) mit der [gPodder-Sync-App](https://apps.nextcloud.com/apps/gpoddersync), ein vollständiger [gPodder](https://gpoddernet.readthedocs.io/en/latest/dev/installation.html)-Server oder der [Micro-GPodder-Server](https://github.com/bohwaz/micro-gpodder-server).
+* Technisch versierteren Benutzern wird dringend empfohlen, **selbst einen Synchronisierungsserver zu betreiben**. Ein selbst betriebener Server ist zuverlässiger und trägt dazu bei, die Belastung der kostenlosen öffentlichen Dienste zu verringern. Es gibt mehrere Optionen:
+  * [Nextcloud](https://nextcloud.com/install/#instructions-server) mit der [gPodder-Sync-App](https://apps.nextcloud.com/apps/gpoddersync) (PHP)
+  * [oPodSync](https://github.com/kd2org/opodsync) (PHP)
+  * [goPodder](https://github.com/cbrgm/gopodder) (Go)
+  * [podsync](https://github.com/bobrippling/podsync) (Rust)
+  * [malipod](https://github.com/eliassoares/malipod-selfhosted) (Python)
+
+Dies sind Drittanbieterprojekte, die nicht mit AntennaPod in Verbindung stehen.
 
 ## Synchronisierung per Nextcloud aktivieren
 

--- a/_i18n/de/documentation/general/synchronization.md
+++ b/_i18n/de/documentation/general/synchronization.md
@@ -28,7 +28,7 @@ Dies sind Drittanbieterprojekte, die nicht mit AntennaPod in Verbindung stehen.
 
 ## Synchronisierung per Nextcloud aktivieren
 
-1. Wenn du ein Nextcloud-Konto hast, installiere die gPodder-Sync-App oder bitte deinen Server-Administrator, dies zu tun
+1. Wenn du ein Nextcloud-Konto hast, installiere die gPodder-Sync-App oder bitten deinen Server-Administrator, dies zu tun
 1. Öffne `Einstellungen` » `Synchronisation` in AntennaPod und tippe auf `Anbieter für Synchronisierung auswählen`
 1. Wähle „gPodder“
 1. Gib die „Server-Adresse“ (die URL oder IP-Adresse des Servers) ein und tippe auf `Weiter zur Anmeldung`
@@ -37,8 +37,8 @@ Dies sind Drittanbieterprojekte, die nicht mit AntennaPod in Verbindung stehen.
 ## Synchronisierung per gPodder aktivieren
 
 1. Erstelle ein Konto auf gpodder.net oder melde dich an, solltest du bereits eines haben
-1. Wenn du ein Konto hast, melde dich auf dem Webserver an und erstelle unter `Subscriptions` » `Devices` ein Gerät für jeden Client, den du nutzt:<br />{{ img-devices | strip }}
-1. Wenn du die Geräte zu deinem Konto hinzugefügt hast, verknüpfe sie über die Schaltfläche „Configure". So hält gpodder.net die aktivierten Geräte automatisch synchron.<br />{{ img-synchronize | strip }}
+1. When you have an account, log in on the webserver and create a device under `Subscriptions` » `Devices` for each client that you use:<br />{{ img-devices | strip }}
+1. When you have added the devices to your account, link them using the "Configure" button. This way, gpodder.net automatically keeps the activated devices synchronized.<br />{{ img-synchronize | strip }}
 1. Öffne `Einstellungen` » `Synchronisation` in AntennaPod und tippe auf `Anbieter für Synchronisierung auswählen`
 1. Wähle „gPodder“
 1. Gib die „Server-Adresse“ (z. B. www.gpodder.net) ein und tippe auf `Weiter zur Anmeldung`

--- a/_i18n/de/documentation/general/synchronization.md
+++ b/_i18n/de/documentation/general/synchronization.md
@@ -28,7 +28,7 @@ Dies sind Drittanbieterprojekte, die nicht mit AntennaPod in Verbindung stehen.
 
 ## Synchronisierung per Nextcloud aktivieren
 
-1. Wenn du ein Nextcloud-Konto hast, installiere die gPodder-Sync-App oder bitten deinen Server-Administrator, dies zu tun
+1. Wenn du ein Nextcloud-Konto hast, installiere die gPodder-Sync-App oder bitte deinen Server-Administrator, dies zu tun
 1. Öffne `Einstellungen` » `Synchronisation` in AntennaPod und tippe auf `Anbieter für Synchronisierung auswählen`
 1. Wähle „gPodder“
 1. Gib die „Server-Adresse“ (die URL oder IP-Adresse des Servers) ein und tippe auf `Weiter zur Anmeldung`
@@ -37,8 +37,8 @@ Dies sind Drittanbieterprojekte, die nicht mit AntennaPod in Verbindung stehen.
 ## Synchronisierung per gPodder aktivieren
 
 1. Erstelle ein Konto auf gpodder.net oder melde dich an, solltest du bereits eines haben
-1. When you have an account, log in on the webserver and create a device under `Subscriptions` » `Devices` for each client that you use:<br />{{ img-devices | strip }}
-1. When you have added the devices to your account, link them using the "Configure" button. This way, gpodder.net automatically keeps the activated devices synchronized.<br />{{ img-synchronize | strip }}
+1. Wenn du ein Konto hast, melde dich auf dem Webserver an und erstelle unter `Subscriptions` » `Devices` ein Gerät für jeden Client, den du nutzt:<br />{{ img-devices | strip }}
+1. Wenn du die Geräte zu deinem Konto hinzugefügt hast, verknüpfe sie über die Schaltfläche „Configure". So hält gpodder.net die aktivierten Geräte automatisch synchron.<br />{{ img-synchronize | strip }}
 1. Öffne `Einstellungen` » `Synchronisation` in AntennaPod und tippe auf `Anbieter für Synchronisierung auswählen`
 1. Wähle „gPodder“
 1. Gib die „Server-Adresse“ (z. B. www.gpodder.net) ein und tippe auf `Weiter zur Anmeldung`

--- a/_i18n/en/documentation/general/synchronization.md
+++ b/_i18n/en/documentation/general/synchronization.md
@@ -31,9 +31,8 @@ AntennaPod can synchronise your subscriptions and listening progress with other 
 * [gpodder.net](https://gpodder.net/) provides a free gPodder synchronization server that **anyone can sign up** for. Unfortunately, due to the popularity of the service and its limited funding, this server is often overloaded, leading to errors in AntennaPod.
 * More technically inclined users are strongly encouraged to **self-host a synchronization server**. A self-hosted server is more reliable and helps reduce the load on free, public services. There are several options:
   * [Nextcloud](https://nextcloud.com/install/#instructions-server) with the [gPodder Sync app](https://apps.nextcloud.com/apps/gpoddersync) (PHP)
+  * [oPodSync](https://github.com/kd2org/opodsync) (PHP)
   * [goPodder](https://github.com/cbrgm/gopodder) (Go)
-  * [Micro GPodder server](https://github.com/bohwaz/micro-gpodder-server) (PHP)
-  * [opodsync](https://github.com/kd2org/opodsync) (PHP)
   * [podsync](https://github.com/bobrippling/podsync) (Rust)
   * [malipod](https://github.com/eliassoares/malipod-selfhosted) (Python)
 

--- a/_i18n/en/documentation/general/synchronization.md
+++ b/_i18n/en/documentation/general/synchronization.md
@@ -60,4 +60,4 @@ These are third-party projects not affiliated with AntennaPod.
 7. Enter the 'Username' and 'Password' and tap `Log in`
 8. Select the device that you created on the server
 
-**NOTE:** Did you create a device while setting up synchronisation in AntennaPod, rather creating a device in advance on the website? Then be sure to press the `Force sync` button upload the played state of all previously listened to episodes. If you don't do this, only podcasts that were added **after** linking the devices will be synchronized. There is an [open issue for gpodder.net](https://github.com/gpodder/mygpo/issues/388) that requests to change the behavior.
+**NOTE:** Did you create a device while setting up synchronisation in AntennaPod, rather than creating a device in advance on the website? Then be sure to press the `Force sync` button to upload the played state of all previously listened to episodes. If you don't do this, only podcasts that were added **after** linking the devices will be synchronized. There is an [open issue for gpodder.net](https://github.com/gpodder/mygpo/issues/388) that requests to change the behavior.

--- a/_i18n/en/documentation/general/synchronization.md
+++ b/_i18n/en/documentation/general/synchronization.md
@@ -34,7 +34,7 @@ AntennaPod can synchronise your subscriptions and listening progress with other 
   * [goPodder](https://github.com/cbrgm/gopodder) (Go)
   * [Micro GPodder server](https://github.com/bohwaz/micro-gpodder-server) (PHP)
   * [opodsync](https://github.com/kd2org/opodsync) (PHP)
-  * [podsync](https://github.com/bobrippling/podsync) (Python)
+  * [podsync](https://github.com/bobrippling/podsync) (Rust)
   * [malipod](https://github.com/eliassoares/malipod-selfhosted) (Python)
 
 These are third-party projects not affiliated with AntennaPod.

--- a/_i18n/en/documentation/general/synchronization.md
+++ b/_i18n/en/documentation/general/synchronization.md
@@ -27,8 +27,17 @@
 <!-- mdpo-enable -->
 
 AntennaPod can synchronise your subscriptions and listening progress with other AntennaPod installations as well as other (desktop) apps. To set up synchronisation, you need a server - the central point through which your data is shared with other devices. You have several options for this:
+
 * [gpodder.net](https://gpodder.net/) provides a free gPodder synchronization server that **anyone can sign up** for. Unfortunately, due to the popularity of the service and its limited funding, this server is often overloaded, leading to errors in AntennaPod.
-* More technically inclined users are strongly encouraged to **self-host a synchronization server**. A self-hosted server is more reliable and helps reduce the load on free, public services. There are several options: [Nextcloud](https://nextcloud.com/install/#instructions-server) with the [gPodder Sync app](https://apps.nextcloud.com/apps/gpoddersync), a full [gPodder](https://gpoddernet.readthedocs.io/en/latest/dev/installation.html) server, or the [Micro GPodder server](https://github.com/bohwaz/micro-gpodder-server).
+* More technically inclined users are strongly encouraged to **self-host a synchronization server**. A self-hosted server is more reliable and helps reduce the load on free, public services. There are several options:
+  * [Nextcloud](https://nextcloud.com/install/#instructions-server) with the [gPodder Sync app](https://apps.nextcloud.com/apps/gpoddersync) (PHP)
+  * [goPodder](https://github.com/cbrgm/gopodder) (Go)
+  * [Micro GPodder server](https://github.com/bohwaz/micro-gpodder-server) (PHP)
+  * [opodsync](https://github.com/kd2org/opodsync) (PHP)
+  * [podsync](https://github.com/bobrippling/podsync) (Python)
+  * [malipod](https://github.com/eliassoares/malipod-selfhosted) (Python)
+
+These are third-party projects not affiliated with AntennaPod.
 
 
 ## Enable synchronization via Nextcloud


### PR DESCRIPTION
Addresses #513.

Rewords the self-hosted sync section into a list format showing each server with its programming language, as suggested by @ByteHamster. Adds opodsync, podsync, malipod, and goPodder. Includes a note that these are third-party projects not affiliated with AntennaPod.