### PR TITLE
Fix broken links

### DIFF
--- a/_blog/2020-06-04-Getting to a new icon.md
+++ b/_blog/2020-06-04-Getting to a new icon.md
@@ -80,4 +80,4 @@ Of course you'd be acknowledged by name on the site and in the app's 'About' sec
 
 ## Interested? Contact us!
 
-Thank you for considering support to this open source app! Reply to the [ad on opensourcedesign.net](https://opensourcedesign.net/jobs/jobs/2020-05-26-new-logo-to-go-with-major-app-update) or get in touch at [email address removed].
+Thank you for considering support to this open source app! Reply to the [ad on opensourcedesign.net](https://web.archive.org/web/20201026134555/https://opensourcedesign.net/jobs/jobs/2020-05-26-new-logo-to-go-with-major-app-update) or get in touch at [email address removed].

--- a/_layouts/event.html
+++ b/_layouts/event.html
@@ -79,4 +79,6 @@ layout: internal
   </div>
 </div>
 
-{% include add-to-calendar-modal.html %}
+{% if status != 'past' %}
+  {% include add-to-calendar-modal.html %}
+{% endif %}


### PR DESCRIPTION
Open source design link and calendar link are dead. Replace the former with archive link and remove the latter.

Closes #523