### PR TITLE
Update external links

### DIFF
--- a/_i18n/en/documentation/general/other-platforms.md
+++ b/_i18n/en/documentation/general/other-platforms.md
@@ -7,12 +7,11 @@ There are (open source) alternatives, however, which we would like to point you 
 
 App|Code|iOS|MacOS|Windows|Linux
 ---|---|:---:|:---:|:---:|:---:
-[Podverse](https://podverse.fm/about)|[<i class="fab fa-github"></i>](https://github.com/podverse/podverse-rn)|✅|✅|❌|❌
+[Podverse](https://podverse.fm/about)|[<i class="fab fa-github"></i>](https://github.com/podverse/podverse)|✅|✅|❌|❌
 [Pocket Casts](https://pocketcasts.com/)|[<i class="fab fa-github"></i>](https://github.com/Automattic/pocket-casts-ios)|✅|❌|❌|❌
 [gPodder](https://gpodder.github.io/)|[<i class="fab fa-github"></i>](https://github.com/gpodder/gpodder)|❌|✅|✅|✅
 [Poddr](https://sn8z.github.io/Poddr/)|[<i class="fab fa-github"></i>](https://github.com/Sn8z/Poddr)|❌|✅|✅|✅
 [Kasts](https://apps.kde.org/kasts/)|[<i class="fab fa-gitlab"></i>](https://invent.kde.org/multimedia/kasts)|❌|❌|❌|✅
-[Vocal](https://vocalproject.net/)|[<i class="fab fa-github"></i>](https://github.com/VocalPodcastProject/vocal)|❌|❌|❌|✅
 [GNOME Podcasts](https://apps.gnome.org/app/org.gnome.Podcasts/)|[<i class="fab fa-gitlab"></i>](https://gitlab.gnome.org/World/podcasts)|❌|❌|❌|✅
 [MusicPod](https://snapcraft.io/musicpod)|[<i class="fab fa-github"></i>](https://github.com/ubuntu-flutter-community/musicpod)|❌|❌|❌|✅
 

--- a/_i18n/en/general/download.md
+++ b/_i18n/en/general/download.md
@@ -46,7 +46,7 @@ Official versions of AntennaPod are available on Google Play and F-Droid:
 <!-- mdpo-disable -->
 <p class="d-flex">
   <a href="https://play.google.com/store/apps/details?id=de.danoeh.antennapod" target="_blank">{{- img-GP | strip -}}</a>
-  <a href="https://f-droid.org/packages/de.danoeh.antennapod" target="_blank">{{- img-FD | strip -}}</a>
+  <a href="https://f-droid.org/packages/de.danoeh.antennapod/" target="_blank">{{- img-FD | strip -}}</a>
 </p>
 <!-- mdpo-enable -->
 


### PR DESCRIPTION
The Vocal player is dead, Podverse moved its repo, and F-Droid redirects to the version with slash in the end.

Closes #525